### PR TITLE
feat: row-count materialized views for /data-quality

### DIFF
--- a/schema/row_count_views.sql
+++ b/schema/row_count_views.sql
@@ -1,0 +1,93 @@
+-- Row-Count Materialized Views for Data Quality Page
+-- One row per (source, month) with COUNT(*) of raw rows. Powers the dashboard's
+-- /data-quality coverage matrix without scanning multi-million-row raw tables
+-- on every page load (ENTSOE alone is 50M+ rows).
+--
+-- Each view is ~90 rows total — refresh is near-instant.
+--
+-- Usage:
+--   psql $DATABASE_URL -f schema/row_count_views.sql
+--
+-- Refresh (run after ETL completes — handled by src/refresh_views.py):
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_<source>_row_counts;
+
+-- ============================================================================
+-- EIA (USA)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_eia_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM eia_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_eia_row_counts ON mv_eia_row_counts (month);
+
+-- ============================================================================
+-- ENTSOE (Europe)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_entsoe_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM entsoe_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_entsoe_row_counts ON mv_entsoe_row_counts (month);
+
+-- ============================================================================
+-- NPP (India)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_npp_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM npp_generation
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_npp_row_counts ON mv_npp_row_counts (month);
+
+-- ============================================================================
+-- ONS (Brazil)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_ons_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM ons_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_ons_row_counts ON mv_ons_row_counts (month);
+
+-- ============================================================================
+-- OE_FACILITY (Australia)
+-- The dashboard's REGION_TABLE maps australia → oe_facility_generation_data.
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_oe_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM oe_facility_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_oe_row_counts ON mv_oe_row_counts (month);
+
+-- ============================================================================
+-- OCCTO (Japan)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_occto_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM occto_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_occto_row_counts ON mv_occto_row_counts (month);
+
+SELECT 'Row-count materialized views created successfully!' AS status;

--- a/src/refresh_views.py
+++ b/src/refresh_views.py
@@ -17,12 +17,17 @@ from sqlalchemy import create_engine, text
 
 load_dotenv()
 
-# Source → list of materialized views to refresh
+# Source → list of materialized views to refresh.
+# `mv_<source>_row_counts` powers the dashboard's /data-quality coverage matrix.
+# EIA and OE only have row-count views (their raw tables are small enough that
+# the dashboard reads them directly for everything else).
 SOURCE_VIEWS = {
-    "entsoe": ["mv_entsoe_monthly", "mv_entsoe_plant_monthly"],
-    "ons": ["mv_ons_monthly", "mv_ons_plant_monthly"],
-    "npp": ["mv_npp_monthly", "mv_npp_plant_monthly"],
-    "occto": ["mv_occto_monthly", "mv_occto_plant_monthly"],
+    "eia": ["mv_eia_row_counts"],
+    "entsoe": ["mv_entsoe_monthly", "mv_entsoe_plant_monthly", "mv_entsoe_row_counts"],
+    "ons": ["mv_ons_monthly", "mv_ons_plant_monthly", "mv_ons_row_counts"],
+    "npp": ["mv_npp_monthly", "mv_npp_plant_monthly", "mv_npp_row_counts"],
+    "oe": ["mv_oe_row_counts"],
+    "occto": ["mv_occto_monthly", "mv_occto_plant_monthly", "mv_occto_row_counts"],
 }
 
 ALL_VIEWS = [v for views in SOURCE_VIEWS.values() for v in views]
@@ -72,9 +77,6 @@ if __name__ == "__main__":
         if source not in SOURCE_VIEWS:
             logger.error(
                 f"Unknown source: {source}. Valid: {', '.join(SOURCE_VIEWS.keys())}"
-            )
-            logger.info(
-                "Note: EIA and OE have no materialized views (tables are small enough)"
             )
             sys.exit(1)
         views = SOURCE_VIEWS[source]


### PR DESCRIPTION
## Summary
- Adds 6 lightweight mat views (`mv_<source>_row_counts`) — one per data source — each carrying `(month, COUNT(*))` per source. ~90 rows each; near-instant to query and refresh.
- Powers the upcoming dashboard `/data-quality` coverage matrix (PR #2 in the dashboard repo). Avoids scanning the 50M-row ENTSOE table on every page load.
- Extends `src/refresh_views.py` to refresh the new views and adds `eia` / `oe` keys (previously absent — those sources had no mat views at all).

## Migration
After merge, run once against Neon:
```bash
psql $DATABASE_URL -f schema/row_count_views.sql
uv run python src/refresh_views.py
```
Subsequent refreshes are handled by the existing `refresh-views` workflow job.

## Test plan
- [ ] `psql $DATABASE_URL -f schema/row_count_views.sql` succeeds and prints success status
- [ ] `uv run python src/refresh_views.py` refreshes all 14 views without error
- [ ] `SELECT * FROM mv_entsoe_row_counts ORDER BY month DESC LIMIT 5;` returns sensible counts (e.g., 2026-04 ≈ 1.5M)
- [ ] Spot-check that Feb 2026 ENTSOE shows the known 360K-row gap vs Jan/Mar