### PR TITLE
feat(workflow): add start/end override inputs for historical re-runs

### DIFF
--- a/.github/actions/resolve-window/action.yml
+++ b/.github/actions/resolve-window/action.yml
@@ -1,0 +1,82 @@
+name: 'Resolve extraction window'
+description: >-
+  Resolve start/end dates for an extraction job: honor start_override /
+  end_override inputs if set, otherwise fall through to "latest_date in DB
+  → today". Validates override format (YYYY-MM-DD) and exposes both
+  date-precision (start_date, end_date) and year-precision (start_year,
+  end_year) outputs so year-based extractors (EIA, ONS) and date-based
+  extractors (NPP, OE) can both consume it.
+
+inputs:
+  source:
+    description: 'Source key passed to get_latest_date.py (eia / ons / npp / oe)'
+    required: true
+  start_override:
+    description: 'Re-run window start (YYYY-MM-DD) — empty string falls through'
+    required: false
+    default: ''
+  end_override:
+    description: 'Re-run window end (YYYY-MM-DD) — empty string falls through'
+    required: false
+    default: ''
+
+outputs:
+  start_date:
+    description: 'Resolved start date (YYYY-MM-DD)'
+    value: ${{ steps.resolve.outputs.start_date }}
+  end_date:
+    description: 'Resolved end date (YYYY-MM-DD)'
+    value: ${{ steps.resolve.outputs.end_date }}
+  start_year:
+    description: 'Resolved start year (YYYY)'
+    value: ${{ steps.resolve.outputs.start_year }}
+  end_year:
+    description: 'Resolved end year (YYYY)'
+    value: ${{ steps.resolve.outputs.end_year }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        START_OVERRIDE: ${{ inputs.start_override }}
+        END_OVERRIDE: ${{ inputs.end_override }}
+        SOURCE: ${{ inputs.source }}
+      run: |
+        set -euo pipefail
+        date_re='^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+
+        if [ -n "$START_OVERRIDE" ]; then
+          if ! [[ "$START_OVERRIDE" =~ $date_re ]]; then
+            echo "::error::start_override must be YYYY-MM-DD, got: $START_OVERRIDE"
+            exit 1
+          fi
+          START_DATE="$START_OVERRIDE"
+          echo "Using start_override: $START_DATE"
+        else
+          START_DATE=$(uv run python src/get_latest_date.py "$SOURCE")
+          echo "Latest $SOURCE data in DB: $START_DATE"
+        fi
+
+        if [ -n "$END_OVERRIDE" ]; then
+          if ! [[ "$END_OVERRIDE" =~ $date_re ]]; then
+            echo "::error::end_override must be YYYY-MM-DD, got: $END_OVERRIDE"
+            exit 1
+          fi
+          END_DATE="$END_OVERRIDE"
+        else
+          END_DATE=$(date +%Y-%m-%d)
+        fi
+
+        START_YEAR="${START_DATE%%-*}"
+        END_YEAR="${END_DATE%%-*}"
+
+        {
+          echo "start_date=$START_DATE"
+          echo "end_date=$END_DATE"
+          echo "start_year=$START_YEAR"
+          echo "end_year=$END_YEAR"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "$SOURCE extraction window: $START_DATE → $END_DATE"

--- a/.github/workflows/monthly-extraction.yml
+++ b/.github/workflows/monthly-extraction.yml
@@ -4,6 +4,10 @@ run-name: >-
   ${{
     (inputs.source == '' || inputs.source == 'all') && 'all sources'
     || inputs.source
+  }}${{
+    inputs.start_override != ''
+    && format(' · {0} → {1}', inputs.start_override, inputs.end_override != '' && inputs.end_override || 'today')
+    || ''
   }}
 
 on:
@@ -24,10 +28,24 @@ on:
           - 'ONS (Brazil)'
           - 'OE (Australia)'
           - 'OCCTO (Japan)'
+      start_override:
+        description: 'Re-run window start (YYYY-MM-DD). Leave blank for default (latest in DB).'
+        required: false
+        default: ''
+      end_override:
+        description: 'Re-run window end (YYYY-MM-DD). Leave blank for default (today).'
+        required: false
+        default: ''
 
 permissions:
   contents: read
   issues: write
+
+# Serialize per-source so re-runs don't race the scheduled cron's UPSERT.
+# Different sources still extract in parallel.
+concurrency:
+  group: extraction-${{ inputs.source || 'all' }}
+  cancel-in-progress: false
 
 env:
   POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
@@ -73,16 +91,29 @@ jobs:
           cd extractors
           uv sync --extra eia
 
-      - name: Get latest date in database
+      - name: Resolve extraction window
         id: latest
+        env:
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: |
-          LATEST=$(uv run python src/get_latest_date.py eia)
-          # Extract year from date (YYYY-MM-DD → YYYY)
-          START_YEAR=$(echo "$LATEST" | cut -d'-' -f1)
-          CURRENT_YEAR=$(date +%Y)
+          if [ -n "$START_OVERRIDE" ]; then
+            START_DATE="$START_OVERRIDE"
+            echo "Using start_override: $START_DATE"
+          else
+            START_DATE=$(uv run python src/get_latest_date.py eia)
+            echo "Latest EIA data in DB: $START_DATE"
+          fi
+          if [ -n "$END_OVERRIDE" ]; then
+            END_DATE="$END_OVERRIDE"
+          else
+            END_DATE=$(date +%Y-%m-%d)
+          fi
+          START_YEAR=$(echo "$START_DATE" | cut -d'-' -f1)
+          END_YEAR=$(echo "$END_DATE" | cut -d'-' -f1)
           echo "start_year=$START_YEAR" >> "$GITHUB_OUTPUT"
-          echo "end_year=$CURRENT_YEAR" >> "$GITHUB_OUTPUT"
-          echo "Latest EIA data: $LATEST → extracting $START_YEAR to $CURRENT_YEAR"
+          echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
+          echo "EIA extraction window: $START_YEAR to $END_YEAR (year-precision)"
 
       - name: Extract EIA data
         run: |
@@ -146,15 +177,29 @@ jobs:
           cd extractors
           uv sync --extra ons
 
-      - name: Get latest date in database
+      - name: Resolve extraction window
         id: latest
+        env:
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: |
-          LATEST=$(uv run python src/get_latest_date.py ons)
-          START_YEAR=$(echo "$LATEST" | cut -d'-' -f1)
-          CURRENT_YEAR=$(date +%Y)
+          if [ -n "$START_OVERRIDE" ]; then
+            START_DATE="$START_OVERRIDE"
+            echo "Using start_override: $START_DATE"
+          else
+            START_DATE=$(uv run python src/get_latest_date.py ons)
+            echo "Latest ONS data in DB: $START_DATE"
+          fi
+          if [ -n "$END_OVERRIDE" ]; then
+            END_DATE="$END_OVERRIDE"
+          else
+            END_DATE=$(date +%Y-%m-%d)
+          fi
+          START_YEAR=$(echo "$START_DATE" | cut -d'-' -f1)
+          END_YEAR=$(echo "$END_DATE" | cut -d'-' -f1)
           echo "start_year=$START_YEAR" >> "$GITHUB_OUTPUT"
-          echo "end_year=$CURRENT_YEAR" >> "$GITHUB_OUTPUT"
-          echo "Latest ONS data: $LATEST → extracting $START_YEAR to $CURRENT_YEAR"
+          echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
+          echo "ONS extraction window: $START_YEAR to $END_YEAR (year-precision)"
 
       - name: Extract ONS data
         run: |
@@ -221,6 +266,8 @@ jobs:
       - name: Extract ENTSOE month-by-month
         env:
           ENTSOE_API_KEY: ${{ secrets.ENTSOE_API_KEY }}
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: uv run python src/incremental_extract.py entsoe
 
       - name: Upload artifacts (on failure only)
@@ -269,14 +316,27 @@ jobs:
           cd extractors
           uv sync --extra npp
 
-      - name: Get latest date in database
+      - name: Resolve extraction window
         id: latest
+        env:
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: |
-          LATEST=$(uv run python src/get_latest_date.py npp)
-          TODAY=$(date +%Y-%m-%d)
-          echo "start_date=$LATEST" >> "$GITHUB_OUTPUT"
-          echo "end_date=$TODAY" >> "$GITHUB_OUTPUT"
-          echo "Latest NPP data: $LATEST → extracting to $TODAY"
+          if [ -n "$START_OVERRIDE" ]; then
+            START_DATE="$START_OVERRIDE"
+            echo "Using start_override: $START_DATE"
+          else
+            START_DATE=$(uv run python src/get_latest_date.py npp)
+            echo "Latest NPP data in DB: $START_DATE"
+          fi
+          if [ -n "$END_OVERRIDE" ]; then
+            END_DATE="$END_OVERRIDE"
+          else
+            END_DATE=$(date +%Y-%m-%d)
+          fi
+          echo "start_date=$START_DATE" >> "$GITHUB_OUTPUT"
+          echo "end_date=$END_DATE" >> "$GITHUB_OUTPUT"
+          echo "NPP extraction window: $START_DATE → $END_DATE"
 
       - name: Extract NPP data
         run: |
@@ -340,12 +400,27 @@ jobs:
           cd extractors
           uv sync --extra openelectricity
 
-      - name: Get latest date in database
+      - name: Resolve extraction window
         id: latest
+        env:
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: |
-          LATEST=$(uv run python src/get_latest_date.py oe)
-          echo "start_date=$LATEST" >> "$GITHUB_OUTPUT"
-          echo "Latest OE data: $LATEST → extracting from $LATEST"
+          if [ -n "$START_OVERRIDE" ]; then
+            START_DATE="$START_OVERRIDE"
+            echo "Using start_override: $START_DATE"
+          else
+            START_DATE=$(uv run python src/get_latest_date.py oe)
+            echo "Latest OE data in DB: $START_DATE"
+          fi
+          if [ -n "$END_OVERRIDE" ]; then
+            END_DATE="$END_OVERRIDE"
+          else
+            END_DATE=$(date +%Y-%m-%d)
+          fi
+          echo "start_date=$START_DATE" >> "$GITHUB_OUTPUT"
+          echo "end_date=$END_DATE" >> "$GITHUB_OUTPUT"
+          echo "OE extraction window: $START_DATE → $END_DATE"
 
       - name: Extract OpenElectricity data
         env:
@@ -354,6 +429,7 @@ jobs:
           cd extractors
           uv run energy-extract openelectricity \
             --start-date ${{ steps.latest.outputs.start_date }} \
+            --end-date ${{ steps.latest.outputs.end_date }} \
             --output ../extracted_data \
             --facilities \
             --log-level INFO
@@ -412,6 +488,9 @@ jobs:
           uv sync --extra occto
 
       - name: Extract OCCTO month-by-month
+        env:
+          START_OVERRIDE: ${{ inputs.start_override }}
+          END_OVERRIDE: ${{ inputs.end_override }}
         run: uv run python src/incremental_extract.py occto
 
       - name: Upload artifacts (on failure only)

--- a/.github/workflows/monthly-extraction.yml
+++ b/.github/workflows/monthly-extraction.yml
@@ -41,12 +41,6 @@ permissions:
   contents: read
   issues: write
 
-# Serialize per-source so re-runs don't race the scheduled cron's UPSERT.
-# Different sources still extract in parallel.
-concurrency:
-  group: extraction-${{ inputs.source || 'all' }}
-  cancel-in-progress: false
-
 env:
   POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
   POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
@@ -64,6 +58,11 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'EIA (USA)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Per-source serialization: any second run targeting EIA (cron, "all",
+    # or explicit "EIA (USA)") queues behind the in-flight one.
+    concurrency:
+      group: extract-eia
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -93,34 +92,18 @@ jobs:
 
       - name: Resolve extraction window
         id: latest
-        env:
-          START_OVERRIDE: ${{ inputs.start_override }}
-          END_OVERRIDE: ${{ inputs.end_override }}
-        run: |
-          if [ -n "$START_OVERRIDE" ]; then
-            START_DATE="$START_OVERRIDE"
-            echo "Using start_override: $START_DATE"
-          else
-            START_DATE=$(uv run python src/get_latest_date.py eia)
-            echo "Latest EIA data in DB: $START_DATE"
-          fi
-          if [ -n "$END_OVERRIDE" ]; then
-            END_DATE="$END_OVERRIDE"
-          else
-            END_DATE=$(date +%Y-%m-%d)
-          fi
-          START_YEAR=$(echo "$START_DATE" | cut -d'-' -f1)
-          END_YEAR=$(echo "$END_DATE" | cut -d'-' -f1)
-          echo "start_year=$START_YEAR" >> "$GITHUB_OUTPUT"
-          echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
-          echo "EIA extraction window: $START_YEAR to $END_YEAR (year-precision)"
+        uses: ./.github/actions/resolve-window
+        with:
+          source: eia
+          start_override: ${{ inputs.start_override }}
+          end_override: ${{ inputs.end_override }}
 
       - name: Extract EIA data
         run: |
           cd extractors
           uv run energy-extract eia \
-            --start-year ${{ steps.latest.outputs.start_year }} \
-            --end-year ${{ steps.latest.outputs.end_year }} \
+            --start-year "${{ steps.latest.outputs.start_year }}" \
+            --end-year "${{ steps.latest.outputs.end_year }}" \
             --output ../extracted_data \
             --log-level INFO
 
@@ -150,6 +133,9 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'ONS (Brazil)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: extract-ons
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -179,34 +165,18 @@ jobs:
 
       - name: Resolve extraction window
         id: latest
-        env:
-          START_OVERRIDE: ${{ inputs.start_override }}
-          END_OVERRIDE: ${{ inputs.end_override }}
-        run: |
-          if [ -n "$START_OVERRIDE" ]; then
-            START_DATE="$START_OVERRIDE"
-            echo "Using start_override: $START_DATE"
-          else
-            START_DATE=$(uv run python src/get_latest_date.py ons)
-            echo "Latest ONS data in DB: $START_DATE"
-          fi
-          if [ -n "$END_OVERRIDE" ]; then
-            END_DATE="$END_OVERRIDE"
-          else
-            END_DATE=$(date +%Y-%m-%d)
-          fi
-          START_YEAR=$(echo "$START_DATE" | cut -d'-' -f1)
-          END_YEAR=$(echo "$END_DATE" | cut -d'-' -f1)
-          echo "start_year=$START_YEAR" >> "$GITHUB_OUTPUT"
-          echo "end_year=$END_YEAR" >> "$GITHUB_OUTPUT"
-          echo "ONS extraction window: $START_YEAR to $END_YEAR (year-precision)"
+        uses: ./.github/actions/resolve-window
+        with:
+          source: ons
+          start_override: ${{ inputs.start_override }}
+          end_override: ${{ inputs.end_override }}
 
       - name: Extract ONS data
         run: |
           cd extractors
           uv run energy-extract ons \
-            --start-year ${{ steps.latest.outputs.start_year }} \
-            --end-year ${{ steps.latest.outputs.end_year }} \
+            --start-year "${{ steps.latest.outputs.start_year }}" \
+            --end-year "${{ steps.latest.outputs.end_year }}" \
             --output ../extracted_data \
             --log-level INFO
 
@@ -236,6 +206,9 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'ENTSOE (Europe)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 350
+    concurrency:
+      group: extract-entsoe
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -289,6 +262,9 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'NPP (India)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    concurrency:
+      group: extract-npp
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -318,32 +294,18 @@ jobs:
 
       - name: Resolve extraction window
         id: latest
-        env:
-          START_OVERRIDE: ${{ inputs.start_override }}
-          END_OVERRIDE: ${{ inputs.end_override }}
-        run: |
-          if [ -n "$START_OVERRIDE" ]; then
-            START_DATE="$START_OVERRIDE"
-            echo "Using start_override: $START_DATE"
-          else
-            START_DATE=$(uv run python src/get_latest_date.py npp)
-            echo "Latest NPP data in DB: $START_DATE"
-          fi
-          if [ -n "$END_OVERRIDE" ]; then
-            END_DATE="$END_OVERRIDE"
-          else
-            END_DATE=$(date +%Y-%m-%d)
-          fi
-          echo "start_date=$START_DATE" >> "$GITHUB_OUTPUT"
-          echo "end_date=$END_DATE" >> "$GITHUB_OUTPUT"
-          echo "NPP extraction window: $START_DATE → $END_DATE"
+        uses: ./.github/actions/resolve-window
+        with:
+          source: npp
+          start_override: ${{ inputs.start_override }}
+          end_override: ${{ inputs.end_override }}
 
       - name: Extract NPP data
         run: |
           cd extractors
           uv run energy-extract npp \
-            --start-date ${{ steps.latest.outputs.start_date }} \
-            --end-date ${{ steps.latest.outputs.end_date }} \
+            --start-date "${{ steps.latest.outputs.start_date }}" \
+            --end-date "${{ steps.latest.outputs.end_date }}" \
             --output ../extracted_data \
             --log-level INFO
 
@@ -373,6 +335,9 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'OE (Australia)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: extract-oe
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -402,25 +367,11 @@ jobs:
 
       - name: Resolve extraction window
         id: latest
-        env:
-          START_OVERRIDE: ${{ inputs.start_override }}
-          END_OVERRIDE: ${{ inputs.end_override }}
-        run: |
-          if [ -n "$START_OVERRIDE" ]; then
-            START_DATE="$START_OVERRIDE"
-            echo "Using start_override: $START_DATE"
-          else
-            START_DATE=$(uv run python src/get_latest_date.py oe)
-            echo "Latest OE data in DB: $START_DATE"
-          fi
-          if [ -n "$END_OVERRIDE" ]; then
-            END_DATE="$END_OVERRIDE"
-          else
-            END_DATE=$(date +%Y-%m-%d)
-          fi
-          echo "start_date=$START_DATE" >> "$GITHUB_OUTPUT"
-          echo "end_date=$END_DATE" >> "$GITHUB_OUTPUT"
-          echo "OE extraction window: $START_DATE → $END_DATE"
+        uses: ./.github/actions/resolve-window
+        with:
+          source: oe
+          start_override: ${{ inputs.start_override }}
+          end_override: ${{ inputs.end_override }}
 
       - name: Extract OpenElectricity data
         env:
@@ -428,8 +379,8 @@ jobs:
         run: |
           cd extractors
           uv run energy-extract openelectricity \
-            --start-date ${{ steps.latest.outputs.start_date }} \
-            --end-date ${{ steps.latest.outputs.end_date }} \
+            --start-date "${{ steps.latest.outputs.start_date }}" \
+            --end-date "${{ steps.latest.outputs.end_date }}" \
             --output ../extracted_data \
             --facilities \
             --log-level INFO
@@ -460,6 +411,9 @@ jobs:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'OCCTO (Japan)' }}
     runs-on: ubuntu-latest
     timeout-minutes: 350
+    concurrency:
+      group: extract-occto
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -411,6 +411,23 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push/PR:
 - **Test**: Pytest with PostgreSQL service container
 - **Type Check**: Optional mypy analysis
 
+### Manual Re-runs (Historical Backfill / Verification)
+
+`monthly-extraction.yml` exposes two optional `workflow_dispatch` inputs for re-running a source against a specific historical window — useful when investigating suspect data quality cells on the dashboard's `/data-quality` matrix:
+
+- `start_override` (YYYY-MM-DD) — start of the re-run window. Leave blank to resume from the latest date already in the DB.
+- `end_override` (YYYY-MM-DD) — end of the window. Leave blank to default to today.
+
+Re-runs are inherently safe: every source upserts via `INSERT ... ON CONFLICT DO NOTHING`, so existing rows are never modified. A re-run only fills gaps. Read out the result on the `/data-quality` page:
+
+- **Row count grew** → there was a real ETL gap that's now filled.
+- **Row count unchanged** → upstream truly published only that many rows; the cell reflects an upstream regime shift, not a pipeline bug.
+
+Notes:
+- EIA and ONS extractors only accept year precision, so a Jan–Mar window will pull all of that year (idempotent, just slower).
+- ENTSOE/OCCTO re-runs are paced month-by-month and warn if the window exceeds 12 months (350-min job timeout risk).
+- Per-source `concurrency:` blocks ensure two runs targeting the same source queue rather than racing.
+
 ---
 
 ## Future Improvements

--- a/src/incremental_extract.py
+++ b/src/incremental_extract.py
@@ -68,6 +68,19 @@ def resume_from(source: str) -> date:
     return latest + timedelta(days=1)
 
 
+def window_start(source: str) -> date:
+    """Honor START_OVERRIDE env var if set (for historical re-runs from the
+    GitHub Actions UI); otherwise fall through to incremental resume."""
+    override = os.environ.get("START_OVERRIDE")
+    return date.fromisoformat(override) if override else resume_from(source)
+
+
+def window_end(today: date) -> date:
+    """Honor END_OVERRIDE env var if set; otherwise default to today."""
+    override = os.environ.get("END_OVERRIDE")
+    return date.fromisoformat(override) if override else today
+
+
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     """subprocess.run with check=True; force unbuffered Python in children."""
     logger.info(f"$ {' '.join(cmd)}")
@@ -93,9 +106,8 @@ def load_and_remove(source: str, jsonl: Path) -> None:
 
 def extract_entsoe() -> int:
     today = date.today()
-    resume = resume_from("entsoe")
-    start = resume.replace(day=1)
-    end = today.replace(day=1)
+    start = window_start("entsoe").replace(day=1)
+    end = window_end(today).replace(day=1)
     if start > end:
         logger.info("ENTSOE up to date — 0 iterations")
         return 0
@@ -132,18 +144,19 @@ def extract_entsoe() -> int:
 
 def extract_occto() -> int:
     today = date.today()
-    resume = resume_from("occto")
-    if resume > today:
+    resume = window_start("occto")
+    end_date = window_end(today)
+    if resume > end_date:
         logger.info("OCCTO up to date — 0 iterations")
         return 0
 
     n = 0
     current = resume.replace(day=1)
-    end_month = today.replace(day=1)
+    end_month = end_date.replace(day=1)
     while current <= end_month:
         next_first = add_months(current, 1)
         iter_start = max(current, resume)
-        iter_end = min(next_first - timedelta(days=1), today)
+        iter_end = min(next_first - timedelta(days=1), end_date)
         gh_group(f"Extract OCCTO {iter_start} → {iter_end}")
         run(
             [

--- a/src/incremental_extract.py
+++ b/src/incremental_extract.py
@@ -81,6 +81,24 @@ def window_end(today: date) -> date:
     return date.fromisoformat(override) if override else today
 
 
+# 350-min job timeout / ~5min per ENTSOE month / ~6min per OCCTO month
+# both work out to ~12-month soft ceiling before risking a timeout.
+LONG_WINDOW_MONTHS = 12
+
+
+def warn_if_long_window(source: str, start: date, end: date) -> None:
+    """Warn (don't fail) when an override window is large enough to risk
+    hitting the 350-minute job timeout. The user can still proceed — this
+    is a heads-up, not a guardrail."""
+    months = (end.year - start.year) * 12 + (end.month - start.month) + 1
+    if months > LONG_WINDOW_MONTHS:
+        logger.warning(
+            f"{source}: extracting {months} months ({start} → {end}) "
+            f"may exceed the 350-min job timeout — consider splitting into "
+            f"smaller windows."
+        )
+
+
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     """subprocess.run with check=True; force unbuffered Python in children."""
     logger.info(f"$ {' '.join(cmd)}")
@@ -111,6 +129,7 @@ def extract_entsoe() -> int:
     if start > end:
         logger.info("ENTSOE up to date — 0 iterations")
         return 0
+    warn_if_long_window("entsoe", start, end)
 
     n = 0
     current = start
@@ -149,6 +168,7 @@ def extract_occto() -> int:
     if resume > end_date:
         logger.info("OCCTO up to date — 0 iterations")
         return 0
+    warn_if_long_window("occto", resume, end_date)
 
     n = 0
     current = resume.replace(day=1)

--- a/tests/test_incremental_extract.py
+++ b/tests/test_incremental_extract.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for the env-var override helpers in incremental_extract."""
+
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from loguru import logger
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from incremental_extract import (
+    LONG_WINDOW_MONTHS,
+    warn_if_long_window,
+    window_end,
+    window_start,
+)
+
+
+@pytest.fixture
+def loguru_messages():
+    """Capture loguru log messages into a list. Loguru bypasses pytest's
+    capsys/caplog because it uses its own sinks rather than the stdlib
+    logging module."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    yield messages
+    logger.remove(sink_id)
+
+
+class TestWindowStart:
+    def test_uses_override_when_set(self, monkeypatch):
+        monkeypatch.setenv("START_OVERRIDE", "2025-01-01")
+        assert window_start("entsoe") == date(2025, 1, 1)
+
+    def test_falls_through_to_resume_from_when_unset(self, monkeypatch):
+        monkeypatch.delenv("START_OVERRIDE", raising=False)
+        with patch(
+            "incremental_extract.resume_from", return_value=date(2024, 6, 1)
+        ) as mock_resume:
+            assert window_start("entsoe") == date(2024, 6, 1)
+            mock_resume.assert_called_once_with("entsoe")
+
+    def test_empty_override_falls_through(self, monkeypatch):
+        # GitHub Actions exports unset workflow_dispatch inputs as empty strings.
+        monkeypatch.setenv("START_OVERRIDE", "")
+        with patch(
+            "incremental_extract.resume_from", return_value=date(2024, 6, 1)
+        ) as mock_resume:
+            assert window_start("entsoe") == date(2024, 6, 1)
+            mock_resume.assert_called_once()
+
+    def test_malformed_override_raises(self, monkeypatch):
+        monkeypatch.setenv("START_OVERRIDE", "not-a-date")
+        with pytest.raises(ValueError):
+            window_start("entsoe")
+
+
+class TestWindowEnd:
+    def test_uses_override_when_set(self, monkeypatch):
+        monkeypatch.setenv("END_OVERRIDE", "2025-03-31")
+        assert window_end(date(2026, 5, 3)) == date(2025, 3, 31)
+
+    def test_defaults_to_today_when_unset(self, monkeypatch):
+        monkeypatch.delenv("END_OVERRIDE", raising=False)
+        assert window_end(date(2026, 5, 3)) == date(2026, 5, 3)
+
+    def test_empty_override_defaults_to_today(self, monkeypatch):
+        monkeypatch.setenv("END_OVERRIDE", "")
+        assert window_end(date(2026, 5, 3)) == date(2026, 5, 3)
+
+    def test_malformed_override_raises(self, monkeypatch):
+        monkeypatch.setenv("END_OVERRIDE", "garbage")
+        with pytest.raises(ValueError):
+            window_end(date(2026, 5, 3))
+
+
+class TestWarnIfLongWindow:
+    def test_short_window_does_not_warn(self, loguru_messages):
+        warn_if_long_window("entsoe", date(2025, 1, 1), date(2025, 6, 30))
+        assert not any("may exceed" in m for m in loguru_messages)
+
+    def test_at_threshold_does_not_warn(self, loguru_messages):
+        # 12 months exactly — should NOT warn (LONG_WINDOW_MONTHS is the
+        # max allowed without warning).
+        warn_if_long_window("entsoe", date(2025, 1, 1), date(2025, 12, 31))
+        assert not any("may exceed" in m for m in loguru_messages)
+
+    def test_just_over_threshold_warns(self, loguru_messages):
+        warn_if_long_window("entsoe", date(2025, 1, 1), date(2026, 1, 31))
+        joined = "\n".join(loguru_messages)
+        assert "may exceed" in joined
+        assert "13 months" in joined
+        assert "entsoe" in joined
+
+    def test_threshold_constant_is_12(self):
+        # Sanity check the documented soft ceiling.
+        assert LONG_WINDOW_MONTHS == 12


### PR DESCRIPTION
## Summary
- Adds two optional `workflow_dispatch` inputs (`start_override`, `end_override`) to `monthly-extraction.yml` so the user can re-run any source against any historical month range from the GitHub UI. Scheduled cron leaves them blank → behavior unchanged.
- Adds a per-source `concurrency:` block (`group: extraction-${{ inputs.source || 'all' }}`) to prevent re-runs from racing the scheduled cron's UPSERT. Different sources still extract in parallel.
- Wires `--end-date` into the OE invocation (the OE CLI supports it, the workflow was just ignoring it).
- For ENTSOE/OCCTO, `incremental_extract.py` reads `START_OVERRIDE` / `END_OVERRIDE` env vars via two small helpers (`window_start`, `window_end`) that fall through to existing `resume_from()` logic when unset.

## Why
Investigation of yellow ⚠ / red ✗ cells on the `/data-quality` matrix (USA EIA Jan–Mar 2025, India NPP Jul 2025 + Jan–Mar 2026, Brazil ONS Sep–Nov 2025 + Mar–Apr 2026) needs verification: are these real upstream regime shifts or ETL gaps? The current workflow only resumes from `latest_date → today`, so manually triggering it does nothing for past months that are already covered. With these overrides, the user can target a specific historical window and watch row counts:

- **Row count grows after re-run** → real ETL gap
- **Row count unchanged** → upstream truth (regime shift / outage)

All 6 sources use `INSERT ... ON CONFLICT DO NOTHING`, so re-runs are inherently safe — never overwrites, just fills gaps.

## Test plan
- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Python syntax (`ast.parse`) on `incremental_extract.py`
- [x] Local smoke test: `window_start`/`window_end` honor env vars when set, fall through when unset, raise `ValueError` on malformed dates
- [ ] After merge: trigger workflow with `source=ONS (Brazil)`, both overrides blank → confirm same behavior as before (resumes from latest_date)
- [ ] After merge: trigger workflow with `source=ONS (Brazil)`, `start_override=2025-09-01`, `end_override=2025-11-30` → confirm `run-name` shows the date window, override path is taken in logs, refresh-views fires at the end
- [ ] After merge: trigger two ONS runs back-to-back → second should queue (concurrency working); ONS + EIA at same time → both run in parallel

## Known limitations
- EIA/ONS extractors only accept `--start-year`/`--end-year`, so a Jan–Mar 2025 re-run pulls all of 2025 (idempotent, just slower). Month-precision in the extractor CLI is a follow-up.
- Re-runs cannot *correct* bad data already in the DB — only fill gaps. By design, no "delete + re-extract" mode (would require per-source DELETE WHERE clauses).