### PR TITLE
fix: critical and high-severity audit findings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from template-repository!")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/database.py
+++ b/src/database.py
@@ -114,7 +114,7 @@ _VALID_SQL_IDENTIFIER = re.compile(r"^[a-z_][a-z0-9_]*$")
 # still restrict to standard SQL-identifier characters to prevent f-string
 # injection in the CREATE DATABASE statement (parameterized queries don't
 # work for DDL).
-_VALID_PG_DATABASE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+_VALID_PG_DATABASE_NAME = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]{0,62}\Z")
 
 # All tables this ETL is allowed to operate on.
 _KNOWN_TABLES = frozenset(

--- a/src/database.py
+++ b/src/database.py
@@ -110,6 +110,12 @@ logger.add(
 
 _VALID_SQL_IDENTIFIER = re.compile(r"^[a-z_][a-z0-9_]*$")
 
+# Database names may be mixed-case in practice (e.g. PowerGeneration), but we
+# still restrict to standard SQL-identifier characters to prevent f-string
+# injection in the CREATE DATABASE statement (parameterized queries don't
+# work for DDL).
+_VALID_PG_DATABASE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
 # All tables this ETL is allowed to operate on.
 _KNOWN_TABLES = frozenset(
     {
@@ -240,10 +246,12 @@ class PowerGenerationDatabase:
         Returns:
             Number of rows actually inserted (excluding duplicates).
         """
-        if bool(conflict_columns) == bool(conflict_expr):
+        if (conflict_columns is None) == (conflict_expr is None):
             raise ValueError(
                 "_upsert_via_staging requires exactly one of "
-                "conflict_columns or conflict_expr"
+                "conflict_columns or conflict_expr (got "
+                f"conflict_columns={conflict_columns!r}, "
+                f"conflict_expr={conflict_expr!r})"
             )
         _validate_table(target_table)
         staging = f"_staging_{target_table}"
@@ -314,7 +322,15 @@ class PowerGenerationDatabase:
         CREATE DATABASE cannot run inside a transaction in Postgres, so the
         connection is opened in AUTOCOMMIT isolation instead of bracketing
         the statement with conn.commit() calls.
+
+        Raises ValueError if self.database isn't a safe SQL identifier
+        (parameterized queries don't work for DDL, so the name is
+        interpolated and must be validated up-front).
         """
+        if not _VALID_PG_DATABASE_NAME.match(self.database):
+            raise ValueError(
+                f"Refusing to CREATE DATABASE with unsafe name: {self.database!r}"
+            )
         try:
             default_conn_string = f"postgresql://{self.username}:{self.password}@{self.host}:{self.port}/postgres"
             if self.sslmode:
@@ -632,6 +648,11 @@ class PowerGenerationDatabase:
                             record["timestamp_ms"] = int(dt.timestamp() * 1000)
                         elif ts is not None:
                             record["timestamp_ms"] = int(ts)
+                        else:
+                            logger.warning(
+                                f"Line {line_num}: timestamp_ms is null — skipping record"
+                            )
+                            continue
 
                     # Fix fuel_type: derive from psr_type (always correct)
                     psr = record.get("psr_type", "")

--- a/src/database.py
+++ b/src/database.py
@@ -216,7 +216,7 @@ class PowerGenerationDatabase:
         self,
         df: pd.DataFrame,
         target_table: str,
-        conflict_columns: list,
+        conflict_columns: list = None,
         conflict_expr: str = None,
     ) -> int:
         """Insert rows via a staging table, skipping duplicates on conflict.
@@ -224,18 +224,27 @@ class PowerGenerationDatabase:
         Uses CREATE TEMP TABLE + COPY + INSERT ... ON CONFLICT DO NOTHING
         for efficient bulk upsert.
 
+        Exactly one of ``conflict_columns`` or ``conflict_expr`` must be
+        provided. Passing both raises ValueError to prevent the silent-ignore
+        bug where the caller assumes the column list applies but the SQL
+        expression silently overrides it.
+
         Args:
             df: DataFrame of rows to insert.
             target_table: Destination table name.
             conflict_columns: List of column names forming the natural key
                 (used when the conflict target is plain columns).
             conflict_expr: Raw SQL expression for the ON CONFLICT target when
-                the unique index uses expressions (e.g. COALESCE). When set,
-                this is used instead of conflict_columns in the ON CONFLICT clause.
+                the unique index uses expressions (e.g. COALESCE).
 
         Returns:
             Number of rows actually inserted (excluding duplicates).
         """
+        if bool(conflict_columns) == bool(conflict_expr):
+            raise ValueError(
+                "_upsert_via_staging requires exactly one of "
+                "conflict_columns or conflict_expr"
+            )
         _validate_table(target_table)
         staging = f"_staging_{target_table}"
         columns = list(df.columns)
@@ -300,31 +309,33 @@ class PowerGenerationDatabase:
             return False
 
     def create_database_if_not_exists(self) -> bool:
-        """Create the database if it doesn't exist."""
+        """Create the database if it doesn't exist.
+
+        CREATE DATABASE cannot run inside a transaction in Postgres, so the
+        connection is opened in AUTOCOMMIT isolation instead of bracketing
+        the statement with conn.commit() calls.
+        """
         try:
-            # Connect to default postgres database to create target database
             default_conn_string = f"postgresql://{self.username}:{self.password}@{self.host}:{self.port}/postgres"
             if self.sslmode:
                 default_conn_string += f"?sslmode={self.sslmode}"
             default_engine = create_engine(default_conn_string)
 
-            with default_engine.connect() as conn:
-                # Check if database exists
-                result = conn.execute(
-                    text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
-                    {"db_name": self.database},
-                )
-
-                if result.fetchone() is None:
-                    # Database doesn't exist, create it
-                    conn.commit()
-                    conn.execute(text(f'CREATE DATABASE "{self.database}"'))
-                    conn.commit()
-                    logger.info("Created database", database=self.database)
-                else:
-                    logger.info("Database already exists", database=self.database)
-
-            default_engine.dispose()
+            try:
+                with default_engine.connect().execution_options(
+                    isolation_level="AUTOCOMMIT"
+                ) as conn:
+                    result = conn.execute(
+                        text("SELECT 1 FROM pg_database WHERE datname = :db_name"),
+                        {"db_name": self.database},
+                    )
+                    if result.fetchone() is None:
+                        conn.execute(text(f'CREATE DATABASE "{self.database}"'))
+                        logger.info("Created database", database=self.database)
+                    else:
+                        logger.info("Database already exists", database=self.database)
+            finally:
+                default_engine.dispose()
             return True
 
         except Exception as e:
@@ -505,7 +516,9 @@ class PowerGenerationDatabase:
 
                 # Record extraction metadata
                 run_id = valid_records[0].get("extraction_run_id", extraction_run_id)
-                start_date, end_date = self._get_date_range_for_run("npp_generation", run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "npp_generation", run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=run_id,
                     source="npp",
@@ -595,18 +608,28 @@ class PowerGenerationDatabase:
                             "extraction_run_id", extraction_run_id
                         )
 
-                    # Convert datetime strings to Unix timestamps in milliseconds
+                    # Convert datetime strings to Unix timestamps in milliseconds.
+                    # Records with unparseable timestamps are skipped with a
+                    # warning — otherwise they'd be coerced to NULL and fail
+                    # the NOT NULL constraint on entsoe_generation_data.
                     if "timestamp_ms" in record:
                         ts = record["timestamp_ms"]
                         if isinstance(ts, str):
                             try:
                                 dt = pd.to_datetime(ts, errors="coerce")
-                                if pd.isnull(dt):
-                                    record["timestamp_ms"] = None
-                                else:
-                                    record["timestamp_ms"] = int(dt.timestamp() * 1000)
-                            except Exception:
-                                record["timestamp_ms"] = None
+                            except Exception as e:
+                                logger.warning(
+                                    f"Line {line_num}: timestamp_ms parse raised "
+                                    f"{type(e).__name__} for value {ts!r} — skipping record"
+                                )
+                                continue
+                            if pd.isnull(dt):
+                                logger.warning(
+                                    f"Line {line_num}: timestamp_ms {ts!r} could not "
+                                    "be parsed — skipping record"
+                                )
+                                continue
+                            record["timestamp_ms"] = int(dt.timestamp() * 1000)
                         elif ts is not None:
                             record["timestamp_ms"] = int(ts)
 
@@ -683,7 +706,9 @@ class PowerGenerationDatabase:
 
             # Record extraction metadata
             entsoe_run_id = first_run_id or extraction_run_id
-            start_date, end_date = self._get_date_range_for_run("entsoe_generation_data", entsoe_run_id)
+            start_date, end_date = self._get_date_range_for_run(
+                "entsoe_generation_data", entsoe_run_id
+            )
             self.insert_extraction_metadata(
                 extraction_run_id=entsoe_run_id,
                 source="entsoe",
@@ -973,7 +998,9 @@ class PowerGenerationDatabase:
 
                 # Record extraction metadata
                 run_id = valid_records[0].get("extraction_run_id", extraction_run_id)
-                start_date, end_date = self._get_date_range_for_run("eia_generation_data", run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "eia_generation_data", run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=run_id,
                     source="eia",
@@ -1066,7 +1093,6 @@ class PowerGenerationDatabase:
                             return self._upsert_via_staging(
                                 df,
                                 "ons_generation_data",
-                                ["timestamp_ms", "plant", "ons_plant_id"],
                                 conflict_expr="timestamp_ms, plant, COALESCE(ons_plant_id, '')",
                             )
 
@@ -1096,7 +1122,9 @@ class PowerGenerationDatabase:
                 logger.warning("Skipped duplicate records", count=total_duplicates)
 
             if total_inserted > 0:
-                start_date, end_date = self._get_date_range_for_run("ons_generation_data", extraction_run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "ons_generation_data", extraction_run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=extraction_run_id,
                     source="ons",
@@ -1212,7 +1240,6 @@ class PowerGenerationDatabase:
                     return self._upsert_via_staging(
                         df,
                         "occto_generation_data",
-                        conflict_columns=["timestamp_ms", "plant"],
                         conflict_expr="timestamp_ms, plant, COALESCE(unit, '')",
                     )
 
@@ -1224,7 +1251,9 @@ class PowerGenerationDatabase:
 
                 # Record extraction metadata
                 run_id = valid_records[0].get("extraction_run_id", extraction_run_id)
-                start_date, end_date = self._get_date_range_for_run("occto_generation_data", run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "occto_generation_data", run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=run_id,
                     source="occto",
@@ -1319,7 +1348,9 @@ class PowerGenerationDatabase:
 
                 # Record extraction metadata
                 run_id = valid_records[0].get("extraction_run_id", extraction_run_id)
-                start_date, end_date = self._get_date_range_for_run("oe_generation_data", run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "oe_generation_data", run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=run_id,
                     source="oe",
@@ -1416,7 +1447,9 @@ class PowerGenerationDatabase:
 
                 # Record extraction metadata
                 run_id = valid_records[0].get("extraction_run_id", extraction_run_id)
-                start_date, end_date = self._get_date_range_for_run("oe_facility_generation_data", run_id)
+                start_date, end_date = self._get_date_range_for_run(
+                    "oe_facility_generation_data", run_id
+                )
                 self.insert_extraction_metadata(
                     extraction_run_id=run_id,
                     source="oe_facility",
@@ -1604,24 +1637,3 @@ class PowerGenerationDatabase:
 def create_power_generation_database() -> PowerGenerationDatabase:
     """Create database instance using environment variables."""
     return PowerGenerationDatabase()
-
-
-if __name__ == "__main__":
-    # Example usage for NPP data ingestion
-    db = create_power_generation_database()
-
-    # Test connection and setup
-    if not db.test_connection():
-        db.create_database_if_not_exists()
-
-    # Create NPP table
-    db.create_npp_table()
-
-    # Example file paths
-    jsonl_file = "/Users/nicholasabad/Desktop/workspace/consulting-christine/india-generation-npp/output/test/npp_test_extraction_2025-12-29_12-21-26.jsonl"
-    metadata_file = "/Users/nicholasabad/Desktop/workspace/consulting-christine/india-generation-npp/output/scrape_metadata_7b7bb7a0-52d7-4241-9fe2-45e852175ade.json"
-
-    # Insert data
-    db.insert_npp_jsonl_data(jsonl_file, metadata_file)
-
-    db.close()


### PR DESCRIPTION
## Summary

Implements the ETL-side fixes from the cross-repo audit. Three commits, six concrete fixes; four audit findings did not survive verification and are documented inline in the commit messages.

### `75b846c` — initial audit fixes

- **Delete `main.py`** (template boilerplate; nothing imports it; workflows invoke `src/database_management.py`).
- **Delete `__main__` block in `src/database.py`** — hardcoded paths to a non-existent `india-generation-npp/` directory and a wrong-arity call to `insert_npp_jsonl_data` (passing a metadata file path where `extraction_run_id` was expected).
- **`_upsert_via_staging`: raise on both args** — previously `conflict_columns` was silently ignored when `conflict_expr` was also set. Added a runtime guard so the API can't be misused.
- **Clean ONS upsert call** — drop the dead `conflict_columns` arg. The list was ignored anyway because `conflict_expr` overrode it.
- **Clean OCCTO upsert call** — same fix; the audit only flagged ONS but OCCTO had the identical issue.
- **ENTSOE timestamp coercion** — when a string value can't be parsed, log a warning with the line number and `continue` instead of silently setting `timestamp_ms=None`, which would violate the `NOT NULL + CHECK (timestamp_ms > 0)` constraint on `entsoe_generation_data` at insert time.
- **`create_database_if_not_exists`** — use AUTOCOMMIT isolation for the CREATE DATABASE statement (CREATE DATABASE can't run inside a transaction), drop the two confusing `conn.commit()` calls, and move `dispose()` into a `finally` block so it runs on inner-block errors.

### `e3c7731` — second-pass tightening (from deep-dive of `75b846c`)

- **Timestamp coerce: handle JSON-null** — add `else: continue` for the case where `record["timestamp_ms"]` is already `None` at entry. The validator catches this too, but defense in depth.
- **Upsert validator: switch to `is None`** — explicit `(conflict_columns is None) == (conflict_expr is None)` so a future caller passing `[]` thinking "use expr only" doesn't hit a confusing error. Error message now includes both values via `!r` for debuggability.
- **Validate DB name before CREATE DATABASE** — new `_VALID_PG_DATABASE_NAME` regex (`^[A-Za-z_][A-Za-z0-9_]{0,62}$`) enforced at the top of `create_database_if_not_exists`. Closes a pre-existing SQL-injection surface where an operator-controlled env var was interpolated into DDL.

### `fc4f691` — regex anchor hygiene (from deep-dive of `e3c7731`)

- Switch `_VALID_PG_DATABASE_NAME` from `^...$` to `\A...\Z`. Python's `$` matches at end-of-string OR just before a final `\n`, so `'foo\n'` slipped through. Exploitability was low (Postgres would just create a weirdly-named DB; the `"` block prevented quote-escape), but `\A/\Z` is strictly start-to-end.

## Audit findings that did NOT survive verification

Documented in `75b846c`'s commit message for future reference:

1. **`test_validator.py` "broken imports"** — `pytest tests/test_validator.py` runs 29 tests cleanly. `load_and_validate_jsonl` is at `validator.py:532`, `save_report` at `validator.py:504`. The audit was wrong.
2. **Latent empty-input bug in `incremental_extract.py`** — NPP has an early-return at `database.py:439-441`. ENTSOE uses `entsoe_run_id = first_run_id or extraction_run_id` so a valid UUID is always present. `_get_date_range_for_run` returns `(None, None)` for empty result sets, and `schema/extraction_metadata.sql` declares both date columns as nullable. Not reproducible.
3. **EIA stringification "asymmetry"** — the stringification at `database.py:941-948` is inside the unconditional `for record in data:` loop. The audit conflated it with the conditional metadata-add block immediately above.
4. **"Unused" row-count materialized views** — they're queried by the **Next.js dashboard** (`nextjs/lib/queries.ts:172-177`, `nextjs/app/data-quality/page.tsx`). The audit scoped only the Streamlit side. Deleting them would have broken `/data-quality`.

## Test plan

- [x] `pytest tests/` — 41 tests pass
- [x] `ruff check src/database.py` clean
- [x] `ruff format --check src/database.py` clean
- [x] Verified all 7 `_upsert_via_staging` callers pass exactly one argument
- [x] Verified ONS/OCCTO `conflict_expr` match the unique-index definitions in `schema/ons_generation.sql` / `schema/occto_generation.sql` exactly
- [x] Verified `_VALID_PG_DATABASE_NAME` regex across 14 edge cases including injection vectors
- [ ] Manual smoke: drop a test DB, run `database_management.py create-database`, confirm it succeeds without warnings under AUTOCOMMIT
- [ ] Manual smoke: deliberately set `POSTGRES_DB="foo; DROP TABLE bar"` and verify CREATE DATABASE refuses with a clear `ValueError`