### PR TITLE
feat(chile): add Chile (Coordinador) source to the ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ power-generation-etl/
 │   ├── ons_generation.sql
 │   ├── oe_generation.sql
 │   ├── oe_facility_generation.sql
-│   ├── materialized_views.sql
+│   ├── occto_generation.sql
+│   ├── chile_generation.sql
 │   ├── extraction_metadata.sql
+│   ├── materialized_views.sql
+│   ├── row_count_views.sql
 │   └── migrations/       # Schema migrations
 │       └── 001_add_unique_constraints.sql
 ├── docs/                 # Documentation
@@ -124,10 +127,10 @@ Each source runs independently and can be retried or backfilled safely.
 
 The pipelines load into **PostgreSQL** (currently Neon, with `sslmode=require`).
 
-- **Source-specific tables**: `eia_generation_data`, `npp_generation_data`, `entsoe_generation_data`, `ons_generation_data`, `oe_generation_data`
-- **Natural key UNIQUE constraints** on each table prevent duplicate rows across re-runs (e.g. `uq_entsoe_natural_key`, `uq_npp_natural_key`)
+- **Source-specific tables**: `eia_generation_data`, `npp_generation`, `entsoe_generation_data`, `ons_generation_data`, `oe_generation_data`, `oe_facility_generation_data`, `occto_generation_data`, `chile_generation_data`
+- **Natural key UNIQUE constraints** on each table prevent duplicate rows across re-runs (e.g. `uq_entsoe_natural_key`, `uq_npp_natural_key`, `uq_ons_natural_key`, `uq_occto_natural_key`, `uq_chile_natural_key`)
 - **Staging table upsert**: data is loaded into a temp staging table, then `INSERT ... ON CONFLICT DO NOTHING` merges into the main table — safe for re-runs and partial overlaps
-- **Materialized views**: `mv_entsoe_monthly`, `mv_entsoe_plant_monthly`, `mv_ons_monthly`, `mv_ons_plant_monthly`, `mv_npp_monthly`, `mv_npp_plant_monthly` pre-aggregate large tables for dashboard performance
+- **Materialized views**: per-source `mv_<source>_monthly` and `mv_<source>_plant_monthly` pre-aggregate the large hourly tables (ENTSOE, ONS, NPP, OCCTO, Chile) for dashboard performance; per-source `mv_<source>_row_counts` power the data-quality coverage matrix
 - **Streaming ingestion**: JSONL files are read line-by-line and inserted in configurable batch sizes to keep memory usage low
 
 Downstream consumers (e.g. Streamlit) **read only from the database**.

--- a/schema/chile_generation.sql
+++ b/schema/chile_generation.sql
@@ -1,0 +1,44 @@
+-- Chile Coordinador Power Generation Data
+-- Hourly per-plant coal generation from the Coordinador Eléctrico Nacional SIP
+-- API (sipubv2). Coal plants are identified via combus_termo == "Carbón" on
+-- /centrales/v4/findByDate; hourly values come from /generacion-real/v3.
+-- Data source: https://sipub.api.coordinador.cl
+
+CREATE TABLE IF NOT EXISTS chile_generation_data (
+    id BIGSERIAL PRIMARY KEY,
+
+    -- Extraction metadata
+    extraction_run_id UUID NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+
+    -- Plant identification
+    plant TEXT NOT NULL,
+    chile_plant_id VARCHAR(100),
+    fuel_type VARCHAR(100),
+
+    -- Location (regional admin division + commune; lat/lon live in plant_crosswalk)
+    region VARCHAR(100),
+    comuna VARCHAR(100),
+
+    -- Time series data
+    timestamp_ms BIGINT NOT NULL,
+    generation_mwh DOUBLE PRECISION NOT NULL,
+    resolution_minutes INTEGER DEFAULT 60,
+
+    -- Data quality constraints
+    CONSTRAINT valid_timestamps_chile CHECK (timestamp_ms > 0 AND created_at_ms > 0),
+    CONSTRAINT non_negative_generation_chile CHECK (generation_mwh >= 0)
+);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_chile_gen_timestamp ON chile_generation_data (timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_chile_gen_plant_time ON chile_generation_data (plant, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_chile_gen_fuel_time ON chile_generation_data (fuel_type, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_chile_gen_region_time ON chile_generation_data (region, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_chile_gen_extraction_run ON chile_generation_data (extraction_run_id);
+CREATE INDEX IF NOT EXISTS idx_chile_gen_plant_id ON chile_generation_data (chile_plant_id);
+
+-- Natural key uniqueness (prevents cross-batch and re-load duplicates)
+-- Uses expression index because chile_plant_id is nullable (NULL != NULL in UNIQUE)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_chile_natural_key
+ON chile_generation_data (timestamp_ms, plant, COALESCE(chile_plant_id, ''));

--- a/schema/materialized_views.sql
+++ b/schema/materialized_views.sql
@@ -12,6 +12,8 @@
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_ons_plant_monthly;
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_npp_monthly;
 --   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_npp_plant_monthly;
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_chile_monthly;
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_chile_plant_monthly;
 
 -- ============================================================================
 -- ENTSOE MATERIALIZED VIEWS
@@ -138,6 +140,41 @@ ORDER BY 1, 2, 3, 4;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_occto_plant_monthly
 ON mv_occto_plant_monthly (month, plant, area_name, fuel_type);
+
+-- ============================================================================
+-- CHILE MATERIALIZED VIEWS
+-- ============================================================================
+
+-- Aggregated by month + fuel_type (for time-series chart)
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_chile_monthly AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000)) AS month,
+    fuel_type,
+    SUM(generation_mwh) AS generation_mwh
+FROM chile_generation_data
+GROUP BY 1, 2
+ORDER BY 1, 2;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_chile_monthly
+ON mv_chile_monthly (month, fuel_type);
+
+-- Aggregated by month + plant + region + comuna + fuel_type (for map).
+-- Coords are NOT carried here — the dashboard joins plant_crosswalk via
+-- get_plant_coordinates('CHILE'), matching the ONS/NPP/OCCTO pattern.
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_chile_plant_monthly AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000)) AS month,
+    plant,
+    region,
+    comuna,
+    fuel_type,
+    SUM(generation_mwh) AS generation_mwh
+FROM chile_generation_data
+GROUP BY 1, 2, 3, 4, 5
+ORDER BY 1, 2, 3, 4, 5;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_chile_plant_monthly
+ON mv_chile_plant_monthly (month, plant, region, comuna, fuel_type);
 
 -- ============================================================================
 SELECT 'Materialized views created successfully!' AS status;

--- a/schema/row_count_views.sql
+++ b/schema/row_count_views.sql
@@ -90,4 +90,17 @@ ORDER BY 1;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_occto_row_counts ON mv_occto_row_counts (month);
 
+-- ============================================================================
+-- CHILE (Coordinador)
+-- ============================================================================
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_chile_row_counts AS
+SELECT
+    DATE_TRUNC('month', TO_TIMESTAMP(timestamp_ms / 1000))::date AS month,
+    COUNT(*) AS row_count
+FROM chile_generation_data
+GROUP BY 1
+ORDER BY 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_chile_row_counts ON mv_chile_row_counts (month);
+
 SELECT 'Row-count materialized views created successfully!' AS status;

--- a/src/backfill_extraction_dates.py
+++ b/src/backfill_extraction_dates.py
@@ -11,7 +11,6 @@ Usage:
 """
 
 import os
-import sys
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -28,6 +27,7 @@ SOURCE_TABLE = {
     "oe": "oe_generation_data",
     "oe_facility": "oe_facility_generation_data",
     "occto": "occto_generation_data",
+    "chile": "chile_generation_data",
 }
 
 

--- a/src/check_crosswalk_drift.py
+++ b/src/check_crosswalk_drift.py
@@ -34,6 +34,7 @@ SOURCE_CHECKS = [
     ("ONS", "ons_generation_data", "plant", "plant_name"),
     ("OE", "oe_facility_generation_data", "facility_code", "plant_code"),
     ("OCCTO", "occto_generation_data", "plant", "plant_name"),
+    ("CHILE", "chile_generation_data", "plant", "plant_name"),
 ]
 
 

--- a/src/database.py
+++ b/src/database.py
@@ -632,7 +632,11 @@ class PowerGenerationDatabase:
                         ts = record["timestamp_ms"]
                         if isinstance(ts, str):
                             try:
-                                dt = pd.to_datetime(ts, errors="coerce")
+                                # utc=True: tz-naive inputs are treated as UTC
+                                # rather than the runner's local time, which
+                                # would shift naive ENTSOE strings by the
+                                # GHA runner offset.
+                                dt = pd.to_datetime(ts, utc=True, errors="coerce")
                             except Exception as e:
                                 logger.warning(
                                     f"Line {line_num}: timestamp_ms parse raised "
@@ -645,7 +649,7 @@ class PowerGenerationDatabase:
                                     "be parsed — skipping record"
                                 )
                                 continue
-                            record["timestamp_ms"] = int(dt.timestamp() * 1000)
+                            record["timestamp_ms"] = int(dt.value // 1_000_000)
                         elif ts is not None:
                             record["timestamp_ms"] = int(ts)
                         else:

--- a/src/database.py
+++ b/src/database.py
@@ -126,6 +126,7 @@ _KNOWN_TABLES = frozenset(
         "oe_generation_data",
         "oe_facility_generation_data",
         "occto_generation_data",
+        "chile_generation_data",
         "extraction_metadata",
         "plant_crosswalk",
         "eia_generator_info",
@@ -410,6 +411,10 @@ class PowerGenerationDatabase:
         """Create OpenElectricity Australia facility generation table."""
         return self._execute_schema_file("oe_facility_generation.sql")
 
+    def create_chile_table(self) -> bool:
+        """Create Chile (Coordinador) generation table."""
+        return self._execute_schema_file("chile_generation.sql")
+
     def create_extraction_metadata_table(self) -> bool:
         """Create extraction metadata table."""
         return self._execute_schema_file("extraction_metadata.sql")
@@ -425,6 +430,7 @@ class PowerGenerationDatabase:
             "oe",
             "oe_facility",
             "occto",
+            "chile",
             "extraction_metadata",
         ]:
             try:
@@ -1555,6 +1561,171 @@ class PowerGenerationDatabase:
         if row is None or row[0] is None:
             return (None, None)
         return (row[0], row[1])
+
+    def insert_chile_jsonl_data(
+        self,
+        jsonl_file_path: str,
+        extraction_run_id: str = None,
+        validation_report_path: str = None,
+        chunk_lines: int = 50_000,
+    ) -> Tuple[bool, Optional[ValidationReport]]:
+        """Insert Chile (Coordinador) data from JSONL file with validation.
+
+        Processes the file in streaming chunks. Tolerates both the post-fixup
+        extractor JSONL (with `chile_plant_id`) and legacy JSONL produced
+        before the convention-alignment commit (with `plant_id`, plus
+        `country_code`/`latitude`/`longitude`) — the legacy id is renamed and
+        the extras are dropped to match the table schema. Coordinates live in
+        plant_crosswalk, not in chile_generation_data, mirroring ONS.
+
+        Returns:
+            Tuple of (success, validation_report)
+        """
+        try:
+            if extraction_run_id is None:
+                extraction_run_id = str(uuid.uuid4())
+            created_at_ms = int(datetime.now().timestamp() * 1000)
+
+            # Columns kept on insert (anything else from the JSONL is dropped).
+            keep_cols = [
+                "extraction_run_id",
+                "created_at_ms",
+                "plant",
+                "chile_plant_id",
+                "fuel_type",
+                "region",
+                "comuna",
+                "timestamp_ms",
+                "generation_mwh",
+                "resolution_minutes",
+            ]
+
+            validator = DataValidator()
+            total_inserted = 0
+            total_valid = 0
+            total_invalid = 0
+            total_duplicates = 0
+            total_records = 0
+            chunk_num = 0
+
+            with open(jsonl_file_path, "r") as f:
+                while True:
+                    # Read a chunk of lines
+                    chunk = []
+                    for _ in range(chunk_lines):
+                        line = f.readline()
+                        if not line:
+                            break
+                        line = line.strip()
+                        if line:
+                            chunk.append(json.loads(line))
+
+                    if not chunk:
+                        break
+
+                    chunk_num += 1
+
+                    # Normalize legacy column name from pre-fixup extractor runs.
+                    for record in chunk:
+                        if "chile_plant_id" not in record and "plant_id" in record:
+                            record["chile_plant_id"] = record.pop("plant_id")
+
+                    # Add extraction metadata if absent
+                    has_extraction_run_id = "extraction_run_id" in chunk[0]
+                    has_created_at_ms = "created_at_ms" in chunk[0]
+
+                    for record in chunk:
+                        if not has_extraction_run_id:
+                            record["extraction_run_id"] = extraction_run_id
+                        if not has_created_at_ms:
+                            record["created_at_ms"] = created_at_ms
+
+                    # Validate chunk
+                    valid_records, report = validator.validate_file(
+                        chunk, "chile", jsonl_file_path
+                    )
+
+                    total_records += report.total_count
+                    total_valid += report.valid_count
+                    total_invalid += report.invalid_count
+                    total_duplicates += report.duplicate_count
+
+                    # Insert valid records via upsert (skips duplicates)
+                    if valid_records:
+                        df = pd.DataFrame(valid_records)
+                        # Drop columns the extractor emits but the table doesn't
+                        # store (country_code, latitude, longitude). The staging
+                        # table is LIKE chile_generation_data, so unknown columns
+                        # would fail the COPY.
+                        df = df[[c for c in keep_cols if c in df.columns]]
+
+                        def _upsert_chunk():
+                            return self._upsert_via_staging(
+                                df,
+                                "chile_generation_data",
+                                conflict_expr="timestamp_ms, plant, COALESCE(chile_plant_id, '')",
+                            )
+
+                        inserted = self._execute_with_retry(_upsert_chunk)
+                        total_inserted += inserted
+
+                    logger.info(
+                        f"Chunk {chunk_num} done",
+                        chunk_valid=report.valid_count,
+                        total_inserted=total_inserted,
+                    )
+
+                    # Free memory
+                    del chunk, valid_records
+
+            # Log final summary
+            logger.info(
+                "Validation complete",
+                valid=total_valid,
+                invalid=total_invalid,
+                duplicates=total_duplicates,
+                total=total_records,
+            )
+            if total_invalid > 0:
+                logger.warning("Skipped invalid records", count=total_invalid)
+            if total_duplicates > 0:
+                logger.warning("Skipped duplicate records", count=total_duplicates)
+
+            if total_inserted > 0:
+                start_date, end_date = self._get_date_range_for_run(
+                    "chile_generation_data", extraction_run_id
+                )
+                self.insert_extraction_metadata(
+                    extraction_run_id=extraction_run_id,
+                    source="chile",
+                    extraction_timestamp=datetime.now(),
+                    start_date=start_date,
+                    end_date=end_date,
+                    total_records=total_valid,
+                    failed_count=total_invalid,
+                    success=True,
+                )
+                logger.success("Inserted Chile records", count=total_inserted)
+            else:
+                logger.warning("No valid records to insert")
+
+            # Build an aggregate report for the return value
+            aggregate_report = ValidationReport(
+                source_file=jsonl_file_path,
+                total_count=total_records,
+                valid_count=total_valid,
+                invalid_count=total_invalid,
+                duplicate_count=total_duplicates,
+            )
+
+            if validation_report_path:
+                save_report(aggregate_report, validation_report_path)
+
+            return True, aggregate_report
+
+        except Exception as e:
+            logger.error("Failed to insert Chile data", error=str(e))
+            return False, None
 
     def insert_extraction_metadata(
         self,

--- a/src/database_management.py
+++ b/src/database_management.py
@@ -55,6 +55,8 @@ def setup_database(table_type: str = "all"):
         success = db.create_oe_facility_table()
     elif table_type == "occto":
         success = db.create_occto_table()
+    elif table_type == "chile":
+        success = db.create_chile_table()
     else:
         logger.error(f"Unknown table type: {table_type}")
         return False
@@ -155,6 +157,10 @@ def load_data(
         )
     elif data_source == "occto":
         success, report = db.insert_occto_jsonl_data(
+            jsonl_file, validation_report_path=validation_report
+        )
+    elif data_source == "chile":
+        success, report = db.insert_chile_jsonl_data(
             jsonl_file, validation_report_path=validation_report
         )
     else:
@@ -284,7 +290,7 @@ Examples:
     )
     setup_parser.add_argument(
         "table_type",
-        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto"],
+        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
         default="all",
         nargs="?",
         help="Type of tables to create (default: all)",
@@ -296,7 +302,7 @@ Examples:
     )
     update_parser.add_argument(
         "table_type",
-        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto"],
+        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
         default="entsoe",
         nargs="?",
         help="Schema to update (default: entsoe)",
@@ -308,7 +314,7 @@ Examples:
     )
     load_parser.add_argument(
         "data_source",
-        choices=["npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto"],
+        choices=["npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
         help="Type of data source",
     )
     load_parser.add_argument("jsonl_file", help="Path to JSONL file")

--- a/src/database_management.py
+++ b/src/database_management.py
@@ -13,13 +13,10 @@ from database import create_power_generation_database
 from sqlalchemy import text
 
 
-# Configure loguru for CLI output
-logger.remove()
-logger.add(
-    sys.stderr,
-    format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
-    level="INFO",
-)
+# NOTE: do NOT call logger.remove() / logger.add() here. database.py (imported
+# above) already configures a stderr handler AND a daily-rotated file sink at
+# logs/etl_{date}.log. Reconfiguring here wipes both — including the file sink
+# the README documents at the CLI section.
 
 
 def setup_database(table_type: str = "all"):

--- a/src/get_latest_date.py
+++ b/src/get_latest_date.py
@@ -29,6 +29,7 @@ SOURCE_CONFIG = {
         "MAX(TO_TIMESTAMP(timestamp_ms / 1000))::date",
     ),
     "occto": ("occto_generation_data", "MAX(TO_TIMESTAMP(timestamp_ms / 1000))::date"),
+    "chile": ("chile_generation_data", "MAX(TO_TIMESTAMP(timestamp_ms / 1000))::date"),
 }
 
 FALLBACK_DATE = "1970-01-01"

--- a/src/refresh_views.py
+++ b/src/refresh_views.py
@@ -28,6 +28,7 @@ SOURCE_VIEWS = {
     "npp": ["mv_npp_monthly", "mv_npp_plant_monthly", "mv_npp_row_counts"],
     "oe": ["mv_oe_row_counts"],
     "occto": ["mv_occto_monthly", "mv_occto_plant_monthly", "mv_occto_row_counts"],
+    "chile": ["mv_chile_monthly", "mv_chile_plant_monthly", "mv_chile_row_counts"],
 }
 
 ALL_VIEWS = [v for views in SOURCE_VIEWS.values() for v in views]

--- a/src/validator.py
+++ b/src/validator.py
@@ -257,6 +257,24 @@ OE_FACILITY_SCHEMA = {
     "duplicate_key": ("timestamp_ms", "facility_code", "fueltech"),
 }
 
+CHILE_SCHEMA = {
+    "required_fields": {
+        "extraction_run_id": {"type": "str", "validation": "uuid"},
+        "created_at_ms": {"type": "int", "validation": "positive_timestamp"},
+        "timestamp_ms": {"type": "int", "validation": "positive_timestamp"},
+        "plant": {"type": "str", "validation": "non_empty"},
+        "generation_mwh": {"type": "float", "validation": "non_negative"},
+    },
+    "optional_fields": {
+        "chile_plant_id": {"type": "str_or_null", "validation": None},
+        "fuel_type": {"type": "str_or_null", "validation": None},
+        "region": {"type": "str_or_null", "validation": None},
+        "comuna": {"type": "str_or_null", "validation": None},
+        "resolution_minutes": {"type": "int_or_null", "validation": None},
+    },
+    "duplicate_key": ("timestamp_ms", "plant", "chile_plant_id"),
+}
+
 
 class DataValidator:
     """Validates power generation data records."""
@@ -270,6 +288,7 @@ class DataValidator:
             "oe": OE_SCHEMA,
             "oe_facility": OE_FACILITY_SCHEMA,
             "occto": OCCTO_SCHEMA,
+            "chile": CHILE_SCHEMA,
         }
 
     def _is_valid_uuid(self, value: str) -> bool:
@@ -433,6 +452,10 @@ class DataValidator:
     def validate_oe_facility_record(self, record: Dict[str, Any]) -> ValidationResult:
         """Validate a single OpenElectricity Australia facility record."""
         return self._validate_record(record, OE_FACILITY_SCHEMA)
+
+    def validate_chile_record(self, record: Dict[str, Any]) -> ValidationResult:
+        """Validate a single Chile (Coordinador) record."""
+        return self._validate_record(record, CHILE_SCHEMA)
 
     def _get_duplicate_key(
         self, record: Dict[str, Any], key_fields: Tuple[str, ...]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -130,6 +130,51 @@ class TestDataValidatorNPP:
         assert result.valid is True
 
 
+class TestDataValidatorChile:
+    """Tests for Chile (Coordinador) data validation."""
+
+    def setup_method(self):
+        self.validator = DataValidator()
+        self.current_time_ms = int(time.time() * 1000)
+        self.valid_record = {
+            "extraction_run_id": "550e8400-e29b-41d4-a716-446655440000",
+            "created_at_ms": self.current_time_ms,
+            "timestamp_ms": self.current_time_ms - 1000,
+            "plant": "TER HORNITOS",
+            "chile_plant_id": "395",
+            "fuel_type": "Carbón",
+            "region": "Antofagasta",
+            "comuna": "Mejillones",
+            "generation_mwh": 163.13,
+            "resolution_minutes": 60,
+        }
+
+    def test_valid_record(self):
+        result = self.validator.validate_chile_record(self.valid_record)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_missing_required_field(self):
+        record = self.valid_record.copy()
+        del record["plant"]
+        result = self.validator.validate_chile_record(record)
+        assert result.valid is False
+        assert any("missing required field: plant" in e for e in result.errors)
+
+    def test_negative_generation(self):
+        record = self.valid_record.copy()
+        record["generation_mwh"] = -50.0
+        result = self.validator.validate_chile_record(record)
+        assert result.valid is False
+        assert any("non-negative" in e for e in result.errors)
+
+    def test_optional_chile_plant_id_missing(self):
+        record = self.valid_record.copy()
+        del record["chile_plant_id"]
+        result = self.validator.validate_chile_record(record)
+        assert result.valid is True
+
+
 class TestDataValidatorEIA:
     """Tests for EIA data validation."""
 


### PR DESCRIPTION
## Summary
- Adds **Chile coal generation** as a new ETL source, mirroring the ONS/OCCTO conventions exactly (source-prefixed `chile_plant_id`, native fuel labels, natural-key uniqueness, lean per-plant monthly mat view).
- New table `chile_generation_data` (no lat/lon — coords live in `plant_crosswalk` per the ONS pattern), plus `mv_chile_monthly`, `mv_chile_plant_monthly`, `mv_chile_row_counts`.
- New loader `insert_chile_jsonl_data` that is **forwards- and backwards-compatible** with both the post-fixup and pre-fixup extractor JSONL (renames legacy `plant_id` → `chile_plant_id`, drops `country_code`/`latitude`/`longitude`).
- **Live-loaded** the 7.5-year Chile coal backfill — **665,293 rows** across 12 operating-or-retired coal plants — into Neon during PR development.

## Context
This is the downstream half of the `feat(chile)` work; the matching extractor PR is [nicholas-abad/energy-extractors#2](https://github.com/nicholas-abad/energy-extractors/pull/2). The extractor emits JSONL conforming to the source-prefixed convention; this PR teaches the ETL how to ingest it and provides the materialized views the dashboard needs.

Convention parity was the explicit design constraint. The schema follows `ons_generation.sql` (TEXT plant, source-prefixed id, geography columns, natural-key uniqueness, non-negative generation constraint). The mat view shape mirrors `mv_ons_plant_monthly` (lean — coords come from `plant_crosswalk` via the dashboard's existing `get_plant_coordinates(source)` helper). The loader mirrors `insert_ons_jsonl_data` (streaming, validator, upsert via staging with `ON CONFLICT … DO NOTHING`).

## Changes
| File | Change |
|---|---|
| `schema/chile_generation.sql` (new) | `chile_generation_data` table: `plant` (TEXT), `chile_plant_id` (VARCHAR(100)), `fuel_type` (native "Carbón"), `region`/`comuna`, hourly time series. 6 performance indexes + `uq_chile_natural_key (timestamp_ms, plant, COALESCE(chile_plant_id, ''))`. CHECK constraints: `valid_timestamps_chile`, `non_negative_generation_chile`. |
| `schema/materialized_views.sql` | `mv_chile_monthly` (month + fuel_type) and `mv_chile_plant_monthly` (month + plant + region + comuna + fuel_type); both with unique indexes and added to the REFRESH header block. |
| `schema/row_count_views.sql` | `mv_chile_row_counts` for the dashboard's data-quality matrix. |
| `src/database.py` | `create_chile_table`, `insert_chile_jsonl_data` (chunked, validator-gated, normalises legacy `plant_id`, drops extras, upserts via staging on the natural key). `chile` added to `create_all_tables()` loop. `chile_generation_data` added to `_KNOWN_TABLES` allowlist. |
| `src/database_management.py` | `"chile"` branches in `setup_database()` + `load_data()`; `chile` in the argparse `choices=` for both subcommands. |
| `src/refresh_views.py` | `chile` entry in `SOURCE_VIEWS` (refreshes the three Chile mat views). |
| `src/validator.py` | `CHILE_SCHEMA` (required: extraction_run_id/created_at_ms/timestamp_ms/plant/generation_mwh; optional: chile_plant_id/fuel_type/region/comuna/resolution_minutes; `duplicate_key=(timestamp_ms, plant, chile_plant_id)`). `validate_chile_record` + dispatcher entry. |
| `tests/test_validator.py` | `TestDataValidatorChile` (4 tests: valid, missing required, negative gen, optional-id missing). |

## Verification (run as part of PR development)

### Step 1 — Setup table and mat views on Neon
```bash
uv run python src/database_management.py setup chile
uv run python -c "…apply row_count_views.sql + materialized_views.sql…"
# → chile_generation_data + mv_chile_monthly + mv_chile_plant_monthly + mv_chile_row_counts all exist
```

### Step 2 — Load the 7.5-year backfill JSONL (218 MB, 665,305 lines)
```bash
uv run python src/database_management.py load-data chile \
    output/chile_backfill/chile_generation_2026-05-28_19-32-31_etl.jsonl
# → 14 chunks of 50k lines, ~52 seconds total
# → 665,293 rows inserted (12 records skipped by validator —
#   the pre-fixup extractor's `<NA>` plant_id edge cases)
```

### Step 3 — Refresh + verify
```text
mv_chile_monthly       refreshed in 1.1s
mv_chile_plant_monthly refreshed in 0.8s
mv_chile_row_counts    refreshed in 0.4s

Top plants by total generation 2019-01-01 → 2026-05-28:
  TER SANTA MARIA       Biobío         64,901 hrs    12,469,429 MWh
  TER ANGAMOS           Antofagasta    64,511 hrs    12,398,829 MWh
  TER IEM               Antofagasta    64,899 hrs    11,790,666 MWh
  TER COCHRANE          Antofagasta    64,774 hrs    11,533,971 MWh
  TER CAMPICHE          Valparaíso     64,901 hrs     8,437,872 MWh
  TER BOCAMINA II       Biobío         32,856 hrs     8,190,944 MWh  (retired)
  TER GUACOLDA          Atacama        64,906 hrs     5,480,199 MWh
  TER HORNITOS          Antofagasta    59,441 hrs     4,602,570 MWh
  TER ANDINA            Antofagasta    57,411 hrs     4,547,675 MWh
  TER NORGENER          Antofagasta    52,059 hrs     4,103,567 MWh  (retired)
  TER VENTANAS II       Valparaíso     43,866 hrs     3,782,617 MWh  (retired)
  TER VENTANAS          Valparaíso     30,768 hrs       290,095 MWh  (retired)
```

The retired plants' partial-year hour counts (Bocamina II ~32k, Ventanas ~31k) and the operating plants' near-full coverage (~65k = full 7.5 years × 8,760 hours) are consistent with Chile's published coal-retirement timeline.

## Test plan
- [x] `uv run ruff check src/ tests/` — **All checks passed**
- [x] `uv run pytest tests/test_validator.py -q` — **33 passed, 0 failed** (4 new Chile tests + 29 existing)
- [x] `uv run python src/database_management.py setup chile` — table created
- [x] Apply `row_count_views.sql` + `materialized_views.sql` — 4 Chile objects created on Neon
- [x] `load-data chile <backfill.jsonl>` — 665,293 rows inserted, 14 chunks, no errors
- [x] `refresh_views.py --source chile` — 3 mat views refreshed in ~2.3s
- [x] Sanity queries against Neon — row counts match, per-plant totals plausible, date range correct
- [ ] Downstream — `power-generation-etl` is now ready; PR B (data/plant-data crosswalk) and PR C (dashboard) come next.

## Follow-ups (out of scope for this PR)
- **PR B**: register `"CHILE": {"gppd": "CHL", "gem": "Chile"}` in `data/plant-data/src/build_crosswalk.py`; add `"chile_generation.sql"` to `scripts/bootstrap_neon_db.py SCHEMA_FILES`; populate `plant_crosswalk` with the 14 plants from GEM.
- **PR C**: Streamlit + Next.js dashboard wiring (`get_chile_monthly_by_fuel`, `get_chile_plant_monthly`, `"Carbón" → "Coal"` in the fuel-map, source-selector entries).