### PR TITLE
fix(ci): apply ruff format to chile-touched files

### DIFF
--- a/src/backfill_extraction_dates.py
+++ b/src/backfill_extraction_dates.py
@@ -48,12 +48,14 @@ def main():
     engine = get_engine()
 
     with engine.connect() as conn:
-        rows = conn.execute(text("""
+        rows = conn.execute(
+            text("""
             SELECT extraction_run_id::text, source
             FROM extraction_metadata
             WHERE start_date IS NULL OR end_date IS NULL
             ORDER BY extraction_timestamp DESC
-        """)).fetchall()
+        """)
+        ).fetchall()
 
     logger.info(f"{len(rows)} extraction_metadata rows to backfill")
 

--- a/src/check_crosswalk_drift.py
+++ b/src/check_crosswalk_drift.py
@@ -102,7 +102,9 @@ def main():
         json.dump({"total_missing": total_missing, "by_source": report}, f, indent=2)
 
     if total_missing > 0:
-        logger.warning(f"Drift detected: {total_missing} plants total — see drift_report.json")
+        logger.warning(
+            f"Drift detected: {total_missing} plants total — see drift_report.json"
+        )
     else:
         logger.info("No drift — all plants mapped in crosswalk")
 

--- a/src/database_management.py
+++ b/src/database_management.py
@@ -290,7 +290,17 @@ Examples:
     )
     setup_parser.add_argument(
         "table_type",
-        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
+        choices=[
+            "all",
+            "npp",
+            "entsoe",
+            "eia",
+            "ons",
+            "oe",
+            "oe_facility",
+            "occto",
+            "chile",
+        ],
         default="all",
         nargs="?",
         help="Type of tables to create (default: all)",
@@ -302,7 +312,17 @@ Examples:
     )
     update_parser.add_argument(
         "table_type",
-        choices=["all", "npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
+        choices=[
+            "all",
+            "npp",
+            "entsoe",
+            "eia",
+            "ons",
+            "oe",
+            "oe_facility",
+            "occto",
+            "chile",
+        ],
         default="entsoe",
         nargs="?",
         help="Schema to update (default: entsoe)",


### PR DESCRIPTION
CI has been failing since PR #18 merged because the lint job runs both `ruff check` AND `ruff format --check`. My PR-A deep-dive only ran the former locally. Three files I touched needed line-wrapping (long argparse `choices=[...]` lists after adding "chile"; multiline SQL wrap in backfill_extraction_dates; a long logger.warning line in check_crosswalk_drift). Pure formatting — no functional changes. `ruff check`, `pytest`, and the type-check job were always green.