### PR TITLE
ci(npp): rebuild plant_crosswalk in monthly extraction so new coal plants classify

### DIFF
--- a/.github/workflows/monthly-extraction.yml
+++ b/.github/workflows/monthly-extraction.yml
@@ -537,6 +537,78 @@ jobs:
           retention-days: 14
 
   # ─────────────────────────────────────────────
+  # Rebuild the NPP plant_crosswalk after extraction so newly-appearing plants
+  # get coal_type / coordinates. The dashboard classifies NPP coal via
+  # plant_crosswalk.coal_type (joined by plant name), so without this a new coal
+  # plant shows as non-coal until a manual rebuild. build_crosswalk needs the
+  # GEM + GPPD reference CSVs, which are gitignored (~72 MB, too large for the
+  # repo); provide them via the CROSSWALK_REF_DATA_URL secret — a gzipped tar
+  # unpacking into data/crosswalks/ ("GEM database_*.csv",
+  # global_power_plant_database.csv, eia_plant_lookup.csv). If the secret is
+  # unset the job skips cleanly and check-crosswalk-drift still flags new plants
+  # for a manual rebuild — so this never breaks the monthly run.
+  #
+  # Prereqs: CROSSWALK_REF_DATA_URL secret; EXTRACTORS_REPO_TOKEN must also grant
+  # read access to the plant-data repo.
+  # ─────────────────────────────────────────────
+  rebuild-npp-crosswalk:
+    needs: extract-npp
+    if: ${{ always() && needs.extract-npp.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout ETL repo
+        uses: actions/checkout@v4
+
+      - name: Checkout plant-data repo
+        uses: actions/checkout@v4
+        with:
+          repository: nicholas-abad/plant-data
+          path: plant-data
+          token: ${{ secrets.EXTRACTORS_REPO_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Fetch crosswalk reference data
+        id: refdata
+        env:
+          CROSSWALK_REF_DATA_URL: ${{ secrets.CROSSWALK_REF_DATA_URL }}
+        run: |
+          if [ -z "$CROSSWALK_REF_DATA_URL" ]; then
+            echo "CROSSWALK_REF_DATA_URL not set — skipping crosswalk rebuild."
+            echo "(check-crosswalk-drift will still flag any new plants for a manual rebuild.)"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          curl -fsSL "$CROSSWALK_REF_DATA_URL" -o /tmp/refdata.tar.gz
+          tar -xzf /tmp/refdata.tar.gz -C plant-data/data/crosswalks/
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Rebuild NPP crosswalk rows
+        if: ${{ steps.refdata.outputs.ok == 'true' }}
+        run: |
+          cd plant-data
+          uv sync
+          uv run python -m src.build_crosswalk --sources NPP --no-llm --yes
+
+      - name: Load updated crosswalk into Neon
+        if: ${{ steps.refdata.outputs.ok == 'true' }}
+        run: |
+          cd plant-data
+          uv run python - <<'PY'
+          import sys
+          sys.path.insert(0, "scripts")
+          from bootstrap_neon_db import get_engine, load_unified_crosswalk
+          load_unified_crosswalk(get_engine())
+          PY
+
+  # ─────────────────────────────────────────────
   # Refresh materialized views after all loads
   # ─────────────────────────────────────────────
   refresh-views:

--- a/.github/workflows/monthly-extraction.yml
+++ b/.github/workflows/monthly-extraction.yml
@@ -556,6 +556,9 @@ jobs:
     if: ${{ always() && needs.extract-npp.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: rebuild-npp-crosswalk
+      cancel-in-progress: false
     steps:
       - name: Checkout ETL repo
         uses: actions/checkout@v4
@@ -588,6 +591,15 @@ jobs:
           fi
           curl -fsSL "$CROSSWALK_REF_DATA_URL" -o /tmp/refdata.tar.gz
           tar -xzf /tmp/refdata.tar.gz -C plant-data/data/crosswalks/
+          # Fail loud if the bundle didn't deliver the CSVs build_crosswalk needs.
+          # Otherwise GEM_CSV would be absent, the NPP rebuild would be empty, and
+          # the destructive load below would wipe NPP coal classification in prod.
+          missing=0
+          ls plant-data/data/crosswalks/GEM\ database_*.csv >/dev/null 2>&1 \
+            || { echo "::error::GEM database CSV missing after extracting reference bundle"; missing=1; }
+          test -f "plant-data/data/crosswalks/global_power_plant_database.csv" \
+            || { echo "::error::global_power_plant_database.csv missing after extracting reference bundle"; missing=1; }
+          [ "$missing" = "1" ] && exit 1
           echo "ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Rebuild NPP crosswalk rows
@@ -596,6 +608,24 @@ jobs:
           cd plant-data
           uv sync
           uv run python -m src.build_crosswalk --sources NPP --no-llm --yes
+
+      - name: Verify rebuilt crosswalk before loading
+        if: ${{ steps.refdata.outputs.ok == 'true' }}
+        # Refuse to push a degraded crosswalk: the load DROPs and replaces the
+        # live table, so a near-empty NPP coal set (e.g. GEM data went missing)
+        # must abort here rather than break the dashboard. ~249 NPP coal plants
+        # is the validated baseline; 200 is a safe floor.
+        run: |
+          cd plant-data
+          uv run python - <<'PY'
+          import sys
+          import pandas as pd
+          df = pd.read_parquet("data/crosswalks/unified_plant_crosswalk.parquet")
+          npp_coal = int(((df["source_system"] == "NPP") & (df["coal_type"].notna())).sum())
+          print(f"rebuilt crosswalk: {len(df):,} rows, NPP coal_type = {npp_coal}")
+          if npp_coal < 200:
+              sys.exit(f"ABORT: only {npp_coal} NPP coal plants (< 200) — refusing to load a degraded crosswalk")
+          PY
 
       - name: Load updated crosswalk into Neon
         if: ${{ steps.refdata.outputs.ok == 'true' }}
@@ -639,8 +669,10 @@ jobs:
   # Informational only; opens an issue if new plants need mapping
   # ─────────────────────────────────────────────
   check-crosswalk-drift:
-    needs: refresh-views
-    if: ${{ needs.refresh-views.result == 'success' }}
+    # Depend on the rebuild too, so drift is checked against the rebuilt
+    # crosswalk (not the pre-rebuild state, and not mid-DROP/recreate).
+    needs: [refresh-views, rebuild-npp-crosswalk]
+    if: ${{ always() && needs.refresh-views.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Why
The dashboard classifies NPP coal via `plant_crosswalk.coal_type` (joined on `e.plant = x.plant_name`). The monthly workflow loads NPP generation and *drift-checks* the crosswalk, but **never rebuilds it** — so a newly-commissioned coal plant shows as **non-coal** until a manual rebuild. This closes that gap.

## What
New `rebuild-npp-crosswalk` job (runs after `extract-npp`):
1. Checks out `plant-data`, fetches the GEM + GPPD reference CSVs (gitignored, ~72 MB) from a `CROSSWALK_REF_DATA_URL` secret.
2. `build_crosswalk --sources NPP --no-llm` (reads the new plant universe from Neon).
3. Reloads `plant_crosswalk` via `load_unified_crosswalk`.

**Skip-safe:** if `CROSSWALK_REF_DATA_URL` is unset the job exits cleanly (logs a notice), and `check-crosswalk-drift` still flags new plants for a manual rebuild. So merging this **cannot break the monthly run**.

## To activate (one-time)
- Add secret **`CROSSWALK_REF_DATA_URL`** → a gzipped tar of `GEM database_*.csv`, `global_power_plant_database.csv`, `eia_plant_lookup.csv` that unpacks into `data/crosswalks/`.
- Ensure **`EXTRACTORS_REPO_TOKEN`** also grants read access to the `plant-data` repo.

## Notes
- `--no-llm` is intentional: LLM only affects coordinate fallback for unmatched non-coal plants, not coal classification.
- Until activated, the established manual process (drift issue → local `build_crosswalk` → load) is unchanged.