### PR TITLE
chore: switch extraction schedule monthly → weekly

### DIFF
--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -1,6 +1,6 @@
-name: Monthly Data Extraction
+name: Weekly Data Extraction
 run-name: >-
-  Monthly Data Extraction —
+  Weekly Data Extraction —
   ${{
     (inputs.source == '' || inputs.source == 'all') && 'all sources'
     || inputs.source
@@ -12,7 +12,11 @@ run-name: >-
 
 on:
   schedule:
-    - cron: '0 6 1 * *'  # 1st of each month, 6am UTC
+    # Weekly: Sundays 06:23 UTC. The off-:00 minute reduces the top-of-hour
+    # scheduling congestion that made the old monthly run fire ~5h late.
+    # Each extractor is incremental (last-loaded date → today), so a weekly
+    # cadence just keeps the per-run window small (~7 days).
+    - cron: '23 6 * * 0'
   workflow_dispatch:      # Manual trigger from GitHub UI
     inputs:
       source:
@@ -462,8 +466,8 @@ jobs:
   # ─────────────────────────────────────────────
   # Chile (Coordinador) — Hourly plant-level coal via SIP API
   # Requires CL_API_KEY (Coordinador SIP token). Date via resolve-window.
-  # Default quota is 60 req/hr — monthly increment for 12 coal plants is
-  # roughly 12–36 requests, well within the timeout below.
+  # Default quota is 60 req/hr — a weekly increment for 12 coal plants is
+  # roughly 12 requests, well within the timeout below.
   # ─────────────────────────────────────────────
   extract-chile:
     if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'Chile (Coordinador)' }}
@@ -546,7 +550,7 @@ jobs:
   # unpacking into data/crosswalks/ ("GEM database_*.csv",
   # global_power_plant_database.csv, eia_plant_lookup.csv). If the secret is
   # unset the job skips cleanly and check-crosswalk-drift still flags new plants
-  # for a manual rebuild — so this never breaks the monthly run.
+  # for a manual rebuild — so this never breaks the weekly run.
   #
   # Prereqs: CROSSWALK_REF_DATA_URL secret; EXTRACTORS_REPO_TOKEN must also grant
   # read access to the plant-data repo.
@@ -762,6 +766,7 @@ jobs:
               'extract-npp': '${{ needs.extract-npp.result }}',
               'extract-oe': '${{ needs.extract-oe.result }}',
               'extract-occto': '${{ needs.extract-occto.result }}',
+              'extract-chile': '${{ needs.extract-chile.result }}',
               'refresh-views': '${{ needs.refresh-views.result }}',
               'check-crosswalk-drift': '${{ needs.check-crosswalk-drift.result }}',
             };
@@ -770,7 +775,7 @@ jobs:
               .map(([k, _]) => k);
 
             const body = [
-              `## Monthly Extraction Failed`,
+              `## Weekly Extraction Failed`,
               ``,
               `**Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
               `**Trigger:** ${context.eventName}`,
@@ -788,7 +793,7 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🚨 Monthly extraction failed: ${failed.join(', ')}`,
+              title: `🚨 Weekly extraction failed: ${failed.join(', ')}`,
               body: body,
               labels: ['extraction-failure', 'automated'],
             });

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push/PR:
 
 ### Manual Re-runs (Historical Backfill / Verification)
 
-`monthly-extraction.yml` exposes two optional `workflow_dispatch` inputs for re-running a source against a specific historical window — useful when investigating suspect data quality cells on the dashboard's `/data-quality` matrix:
+`weekly-extraction.yml` exposes two optional `workflow_dispatch` inputs for re-running a source against a specific historical window — useful when investigating suspect data quality cells on the dashboard's `/data-quality` matrix:
 
 - `start_override` (YYYY-MM-DD) — start of the re-run window. Leave blank to resume from the latest date already in the DB.
 - `end_override` (YYYY-MM-DD) — end of the window. Leave blank to default to today.


### PR DESCRIPTION
## What

Switches the scheduled ETL extraction from **monthly** to **weekly** per request, and renames the workflow file `monthly-extraction.yml` → `weekly-extraction.yml` to match.

## Changes

- **Schedule:** `cron '0 6 1 * *'` (1st of month, 06:00 UTC) → `'23 6 * * 0'` (**Sundays 06:23 UTC**). The off-`:00` minute reduces the top-of-hour scheduling congestion that made the monthly run fire ~5h late on 2026-06-01.
- **Branding:** workflow `name`, `run-name`, and failure-issue title/heading "Monthly" → "Weekly". (Left "Monthly generator-level data" on EIA — that's the *data* granularity, not the schedule.)
- **Bug fix:** `notify-failure` job's `jobs` report map was missing `extract-chile` (it's in `needs[]` but wasn't in the object), so a Chile-only failure would have produced an empty failed-jobs list and a useless issue. Added it.

## Why weekly is safe / better here

Every extractor is **incremental** (resolves its window from the last-loaded date in the DB → today), so cadence only controls how often it runs — a weekly run just keeps each window ~7 days instead of ~30. Smaller windows = faster jobs, less timeout risk.

It also **fixes the observed OCCTO failure**: the 2026-06-01 scheduled run's `extract-occto` failed with `ValueError: No data could be retrieved between 2026-06-01 and 2026-06-01` — the incremental window was a single day ("today"), and OCCTO's portal publishes with a lag, so all 10 areas returned empty → hard error. A 7-day weekly window always contains already-published days, so the "entire window empty" error can't trigger.

## Up-to-date check (no change needed)

Every extract job checks out `nicholas-abad/energy-extractors` with **no `ref:`** → default branch `main`, which already includes all merged correctness fixes (NPP, OE unit-sum + date_end, Chile unit-sum + tz, OCCTO chunk_days=3). The workflow is current.