### PR TITLE
fix: make silent ETL failure modes fail loudly (audit package 2)

### DIFF
--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -751,7 +751,7 @@ jobs:
   # Notify on failure — create GitHub Issue
   # ─────────────────────────────────────────────
   notify-failure:
-    needs: [extract-eia, extract-ons, extract-entsoe, extract-npp, extract-oe, extract-occto, extract-chile, refresh-views, check-crosswalk-drift]
+    needs: [extract-eia, extract-ons, extract-entsoe, extract-npp, extract-oe, extract-occto, extract-chile, rebuild-npp-crosswalk, refresh-views, check-crosswalk-drift]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:

--- a/src/database.py
+++ b/src/database.py
@@ -311,10 +311,10 @@ class PowerGenerationDatabase:
                 return True
 
             self._execute_with_retry(_test)
-            logger.info("Database connection successful", database=self.database)
+            logger.info(f"Database connection successful: {self.database}")
             return True
         except Exception as e:
-            logger.error("Database connection failed", error=str(e))
+            logger.error(f"Database connection failed: {e}")
             return False
 
     def create_database_if_not_exists(self) -> bool:
@@ -348,15 +348,15 @@ class PowerGenerationDatabase:
                     )
                     if result.fetchone() is None:
                         conn.execute(text(f'CREATE DATABASE "{self.database}"'))
-                        logger.info("Created database", database=self.database)
+                        logger.info(f"Created database: {self.database}")
                     else:
-                        logger.info("Database already exists", database=self.database)
+                        logger.info(f"Database already exists: {self.database}")
             finally:
                 default_engine.dispose()
             return True
 
         except Exception as e:
-            logger.error("Failed to create database", error=str(e))
+            logger.error(f"Failed to create database: {e}")
             return False
 
     def _execute_schema_file(self, schema_filename: str) -> bool:
@@ -370,17 +370,15 @@ class PowerGenerationDatabase:
             with self.engine.connect() as conn:
                 conn.execute(text(schema_sql))
                 conn.commit()
-                logger.info("Schema executed successfully", schema=schema_filename)
+                logger.info(f"Schema executed successfully: {schema_filename}")
 
             return True
 
         except FileNotFoundError:
-            logger.error("Schema file not found", path=str(schema_path))
+            logger.error(f"Schema file not found: {schema_path}")
             return False
         except Exception as e:
-            logger.error(
-                "Failed to execute schema", schema=schema_filename, error=str(e)
-            )
+            logger.error(f"Failed to execute schema {schema_filename}: {e}")
             return False
 
     def create_npp_table(self) -> bool:
@@ -437,11 +435,9 @@ class PowerGenerationDatabase:
                 method = getattr(self, f"create_{table_type}_table")
                 if not method():
                     success = False
-                    logger.error("Failed to create table", table_type=table_type)
+                    logger.error(f"Failed to create table: {table_type}")
             except Exception as e:
-                logger.error(
-                    "Error creating table", table_type=table_type, error=str(e)
-                )
+                logger.error(f"Error creating table {table_type}: {e}")
                 success = False
 
         if success:
@@ -506,16 +502,12 @@ class PowerGenerationDatabase:
 
             # Log validation summary
             logger.info(
-                "Validation complete",
-                valid=report.valid_count,
-                total=report.total_count,
+                f"Validation complete: {report.valid_count}/{report.total_count} valid"
             )
             if report.invalid_count > 0:
-                logger.warning("Skipped invalid records", count=report.invalid_count)
+                logger.warning(f"Skipped invalid records: {report.invalid_count}")
             if report.duplicate_count > 0:
-                logger.warning(
-                    "Skipped duplicate records", count=report.duplicate_count
-                )
+                logger.warning(f"Skipped duplicate records: {report.duplicate_count}")
 
             # Save validation report if requested
             if validation_report_path:
@@ -552,12 +544,18 @@ class PowerGenerationDatabase:
                     success=True,
                 )
             else:
-                logger.warning("No valid records to insert")
+                if report.total_count > 0 and report.invalid_count > 0:
+                    logger.error(
+                        f"All {report.total_count} records failed validation - "
+                        "treating load as FAILED (extractor schema drift?)"
+                    )
+                    return False, report
+                logger.warning("No valid records to insert (empty input)")
 
             return True, report
 
         except Exception as e:
-            logger.error("Failed to insert NPP data", error=str(e))
+            logger.error(f"Failed to insert NPP data: {e}")
             return False, None
 
     def insert_entsoe_jsonl_data(
@@ -724,6 +722,19 @@ class PowerGenerationDatabase:
                 invalid_count=total_invalid,
                 duplicate_count=total_duplicate,
             )
+
+            if (
+                report.total_count > 0
+                and report.valid_count == 0
+                and report.invalid_count > 0
+            ):
+                logger.error(
+                    f"All {report.total_count:,} ENTSO-E records failed validation - "
+                    "treating load as FAILED (extractor schema drift?)"
+                )
+                if validation_report_path:
+                    save_report(report, validation_report_path)
+                return False, report
 
             # Log final summary
             logger.success(
@@ -995,16 +1006,12 @@ class PowerGenerationDatabase:
 
             # Log validation summary
             logger.info(
-                "Validation complete",
-                valid=report.valid_count,
-                total=report.total_count,
+                f"Validation complete: {report.valid_count}/{report.total_count} valid"
             )
             if report.invalid_count > 0:
-                logger.warning("Skipped invalid records", count=report.invalid_count)
+                logger.warning(f"Skipped invalid records: {report.invalid_count}")
             if report.duplicate_count > 0:
-                logger.warning(
-                    "Skipped duplicate records", count=report.duplicate_count
-                )
+                logger.warning(f"Skipped duplicate records: {report.duplicate_count}")
 
             # Save validation report if requested
             if validation_report_path:
@@ -1043,12 +1050,18 @@ class PowerGenerationDatabase:
                     success=True,
                 )
             else:
-                logger.warning("No valid records to insert")
+                if report.total_count > 0 and report.invalid_count > 0:
+                    logger.error(
+                        f"All {report.total_count} records failed validation - "
+                        "treating load as FAILED (extractor schema drift?)"
+                    )
+                    return False, report
+                logger.warning("No valid records to insert (empty input)")
 
             return True, report
 
         except Exception as e:
-            logger.error("Failed to insert EIA data", error=str(e))
+            logger.error(f"Failed to insert EIA data: {e}")
             return False, None
 
     def insert_ons_jsonl_data(
@@ -1148,9 +1161,9 @@ class PowerGenerationDatabase:
                 total=total_records,
             )
             if total_invalid > 0:
-                logger.warning("Skipped invalid records", count=total_invalid)
+                logger.warning(f"Skipped invalid records: {total_invalid}")
             if total_duplicates > 0:
-                logger.warning("Skipped duplicate records", count=total_duplicates)
+                logger.warning(f"Skipped duplicate records: {total_duplicates}")
 
             if total_inserted > 0:
                 start_date, end_date = self._get_date_range_for_run(
@@ -1166,7 +1179,7 @@ class PowerGenerationDatabase:
                     failed_count=total_invalid,
                     success=True,
                 )
-                logger.success("Inserted ONS records", count=total_inserted)
+                logger.success(f"Inserted ONS records: {total_inserted}")
             else:
                 logger.warning("No valid records to insert")
 
@@ -1182,10 +1195,17 @@ class PowerGenerationDatabase:
             if validation_report_path:
                 save_report(aggregate_report, validation_report_path)
 
+            if total_records > 0 and total_valid == 0 and total_invalid > 0:
+                logger.error(
+                    f"All {total_records} records failed validation - "
+                    "treating load as FAILED (extractor schema drift?)"
+                )
+                return False, aggregate_report
+
             return True, aggregate_report
 
         except Exception as e:
-            logger.error("Failed to insert ONS data", error=str(e))
+            logger.error(f"Failed to insert ONS data: {e}")
             return False, None
 
     def insert_occto_jsonl_data(
@@ -1231,16 +1251,12 @@ class PowerGenerationDatabase:
 
             # Log validation summary
             logger.info(
-                "Validation complete",
-                valid=report.valid_count,
-                total=report.total_count,
+                f"Validation complete: {report.valid_count}/{report.total_count} valid"
             )
             if report.invalid_count > 0:
-                logger.warning("Skipped invalid records", count=report.invalid_count)
+                logger.warning(f"Skipped invalid records: {report.invalid_count}")
             if report.duplicate_count > 0:
-                logger.warning(
-                    "Skipped duplicate records", count=report.duplicate_count
-                )
+                logger.warning(f"Skipped duplicate records: {report.duplicate_count}")
 
             # Save validation report if requested
             if validation_report_path:
@@ -1296,12 +1312,18 @@ class PowerGenerationDatabase:
                     success=True,
                 )
             else:
-                logger.warning("No valid records to insert")
+                if report.total_count > 0 and report.invalid_count > 0:
+                    logger.error(
+                        f"All {report.total_count} records failed validation - "
+                        "treating load as FAILED (extractor schema drift?)"
+                    )
+                    return False, report
+                logger.warning("No valid records to insert (empty input)")
 
             return True, report
 
         except Exception as e:
-            logger.error("Failed to insert OCCTO data", error=str(e))
+            logger.error(f"Failed to insert OCCTO data: {e}")
             return False, None
 
     def insert_oe_jsonl_data(
@@ -1345,16 +1367,12 @@ class PowerGenerationDatabase:
 
             # Log validation summary
             logger.info(
-                "Validation complete",
-                valid=report.valid_count,
-                total=report.total_count,
+                f"Validation complete: {report.valid_count}/{report.total_count} valid"
             )
             if report.invalid_count > 0:
-                logger.warning("Skipped invalid records", count=report.invalid_count)
+                logger.warning(f"Skipped invalid records: {report.invalid_count}")
             if report.duplicate_count > 0:
-                logger.warning(
-                    "Skipped duplicate records", count=report.duplicate_count
-                )
+                logger.warning(f"Skipped duplicate records: {report.duplicate_count}")
 
             # Save validation report if requested
             if validation_report_path:
@@ -1393,12 +1411,18 @@ class PowerGenerationDatabase:
                     success=True,
                 )
             else:
-                logger.warning("No valid records to insert")
+                if report.total_count > 0 and report.invalid_count > 0:
+                    logger.error(
+                        f"All {report.total_count} records failed validation - "
+                        "treating load as FAILED (extractor schema drift?)"
+                    )
+                    return False, report
+                logger.warning("No valid records to insert (empty input)")
 
             return True, report
 
         except Exception as e:
-            logger.error("Failed to insert OE data", error=str(e))
+            logger.error(f"Failed to insert OE data: {e}")
             return False, None
 
     def insert_oe_facility_jsonl_data(
@@ -1444,16 +1468,12 @@ class PowerGenerationDatabase:
 
             # Log validation summary
             logger.info(
-                "Validation complete",
-                valid=report.valid_count,
-                total=report.total_count,
+                f"Validation complete: {report.valid_count}/{report.total_count} valid"
             )
             if report.invalid_count > 0:
-                logger.warning("Skipped invalid records", count=report.invalid_count)
+                logger.warning(f"Skipped invalid records: {report.invalid_count}")
             if report.duplicate_count > 0:
-                logger.warning(
-                    "Skipped duplicate records", count=report.duplicate_count
-                )
+                logger.warning(f"Skipped duplicate records: {report.duplicate_count}")
 
             # Save validation report if requested
             if validation_report_path:
@@ -1492,12 +1512,18 @@ class PowerGenerationDatabase:
                     success=True,
                 )
             else:
-                logger.warning("No valid records to insert")
+                if report.total_count > 0 and report.invalid_count > 0:
+                    logger.error(
+                        f"All {report.total_count} records failed validation - "
+                        "treating load as FAILED (extractor schema drift?)"
+                    )
+                    return False, report
+                logger.warning("No valid records to insert (empty input)")
 
             return True, report
 
         except Exception as e:
-            logger.error("Failed to insert OE facility data", error=str(e))
+            logger.error(f"Failed to insert OE facility data: {e}")
             return False, None
 
     def get_record_count(self, table_name: str) -> int:
@@ -1507,10 +1533,10 @@ class PowerGenerationDatabase:
             with self.engine.connect() as conn:
                 result = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}"))
                 count = result.scalar()
-                logger.info("Record count", table=table_name, count=count)
+                logger.info(f"Record count: {table_name}={count}")
                 return count
         except Exception as e:
-            logger.error("Failed to get record count", table=table_name, error=str(e))
+            logger.error(f"Failed to get record count for {table_name}: {e}")
             return 0
 
     def get_all_record_counts(self) -> Dict[str, int]:
@@ -1687,9 +1713,9 @@ class PowerGenerationDatabase:
                 total=total_records,
             )
             if total_invalid > 0:
-                logger.warning("Skipped invalid records", count=total_invalid)
+                logger.warning(f"Skipped invalid records: {total_invalid}")
             if total_duplicates > 0:
-                logger.warning("Skipped duplicate records", count=total_duplicates)
+                logger.warning(f"Skipped duplicate records: {total_duplicates}")
 
             if total_inserted > 0:
                 start_date, end_date = self._get_date_range_for_run(
@@ -1705,7 +1731,7 @@ class PowerGenerationDatabase:
                     failed_count=total_invalid,
                     success=True,
                 )
-                logger.success("Inserted Chile records", count=total_inserted)
+                logger.success(f"Inserted Chile records: {total_inserted}")
             else:
                 logger.warning("No valid records to insert")
 
@@ -1721,10 +1747,17 @@ class PowerGenerationDatabase:
             if validation_report_path:
                 save_report(aggregate_report, validation_report_path)
 
+            if total_records > 0 and total_valid == 0 and total_invalid > 0:
+                logger.error(
+                    f"All {total_records} records failed validation - "
+                    "treating load as FAILED (extractor schema drift?)"
+                )
+                return False, aggregate_report
+
             return True, aggregate_report
 
         except Exception as e:
-            logger.error("Failed to insert Chile data", error=str(e))
+            logger.error(f"Failed to insert Chile data: {e}")
             return False, None
 
     def insert_extraction_metadata(

--- a/src/database.py
+++ b/src/database.py
@@ -1144,9 +1144,8 @@ class PowerGenerationDatabase:
                         total_inserted += inserted
 
                     logger.info(
-                        f"Chunk {chunk_num} done",
-                        chunk_valid=report.valid_count,
-                        total_inserted=total_inserted,
+                        f"Chunk {chunk_num} done: {report.valid_count} valid, "
+                        f"{total_inserted} inserted so far"
                     )
 
                     # Free memory
@@ -1154,11 +1153,8 @@ class PowerGenerationDatabase:
 
             # Log final summary
             logger.info(
-                "Validation complete",
-                valid=total_valid,
-                invalid=total_invalid,
-                duplicates=total_duplicates,
-                total=total_records,
+                f"Validation complete: {total_valid}/{total_records} valid, "
+                f"{total_invalid} invalid, {total_duplicates} duplicates"
             )
             if total_invalid > 0:
                 logger.warning(f"Skipped invalid records: {total_invalid}")
@@ -1696,9 +1692,8 @@ class PowerGenerationDatabase:
                         total_inserted += inserted
 
                     logger.info(
-                        f"Chunk {chunk_num} done",
-                        chunk_valid=report.valid_count,
-                        total_inserted=total_inserted,
+                        f"Chunk {chunk_num} done: {report.valid_count} valid, "
+                        f"{total_inserted} inserted so far"
                     )
 
                     # Free memory
@@ -1706,11 +1701,8 @@ class PowerGenerationDatabase:
 
             # Log final summary
             logger.info(
-                "Validation complete",
-                valid=total_valid,
-                invalid=total_invalid,
-                duplicates=total_duplicates,
-                total=total_records,
+                f"Validation complete: {total_valid}/{total_records} valid, "
+                f"{total_invalid} invalid, {total_duplicates} duplicates"
             )
             if total_invalid > 0:
                 logger.warning(f"Skipped invalid records: {total_invalid}")
@@ -1841,18 +1833,14 @@ class PowerGenerationDatabase:
                 conn.commit()
 
             logger.info(
-                "Extraction metadata inserted",
-                extraction_run_id=extraction_run_id,
-                source=source,
-                total_records=total_records,
+                f"Extraction metadata inserted: {source} "
+                f"run={extraction_run_id} records={total_records}"
             )
             return True
 
         except Exception as e:
             logger.error(
-                "Failed to insert extraction metadata",
-                extraction_run_id=extraction_run_id,
-                error=str(e),
+                f"Failed to insert extraction metadata (run={extraction_run_id}): {e}"
             )
             return False
 

--- a/src/get_latest_date.py
+++ b/src/get_latest_date.py
@@ -35,6 +35,14 @@ SOURCE_CONFIG = {
 FALLBACK_DATE = "1970-01-01"
 
 
+class LatestDateQueryError(RuntimeError):
+    """The latest-date query failed (DB unreachable, auth, timeout, ...).
+
+    Distinct from an empty table: callers must NOT treat this as "no data"
+    or a transient outage triggers a from-scratch re-extraction window.
+    """
+
+
 def get_connection_url() -> str:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASSWORD"]
@@ -63,11 +71,13 @@ def get_latest_date(source: str) -> str:
         with engine.connect() as conn:
             result = conn.execute(text(f"SELECT {expr} AS latest FROM {table}"))
             row = result.fetchone()
-            if row and row[0]:
-                return str(row[0])
     except Exception as e:
-        print(f"Warning: could not query {table}: {e}", file=sys.stderr)
+        raise LatestDateQueryError(f"could not query {table}: {e}") from e
 
+    if row and row[0]:
+        return str(row[0])
+    # Successful query, genuinely empty table — only here is the epoch
+    # fallback correct.
     return FALLBACK_DATE
 
 
@@ -76,5 +86,9 @@ if __name__ == "__main__":
         print(f"Usage: python {sys.argv[0]} <source>", file=sys.stderr)
         sys.exit(1)
 
-    date = get_latest_date(sys.argv[1])
+    try:
+        date = get_latest_date(sys.argv[1])
+    except LatestDateQueryError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
     print(date)

--- a/src/incremental_extract.py
+++ b/src/incremental_extract.py
@@ -191,11 +191,26 @@ def extract_occto() -> int:
                 str(EXTRACTED_DATA),
             ],
         )
-        jsonl = EXTRACTED_DATA / (
-            f"occto_generation_{iter_start.isoformat()}_{iter_end.isoformat()}_etl.jsonl"
-        )
-        if jsonl.exists():
-            load_and_remove("occto", jsonl)
+        # Glob instead of guessing the exact filename (like the ENTSOE branch)
+        # — a silent naming-convention change in the extractor must not mean
+        # "extraction green, nothing loaded, forever".
+        occto_files = sorted(EXTRACTED_DATA.glob("occto_*_etl.jsonl"))
+        if occto_files:
+            for f in occto_files:
+                load_and_remove("occto", f)
+        elif iter_end < today - timedelta(days=2):
+            # A fully-past chunk should always produce a file; only very
+            # recent windows can legitimately be empty (publication lag).
+            raise RuntimeError(
+                f"OCCTO extraction for {iter_start} → {iter_end} succeeded "
+                f"but produced no occto_*_etl.jsonl in {EXTRACTED_DATA} — "
+                f"output naming may have changed"
+            )
+        else:
+            logger.warning(
+                f"No OCCTO output for {iter_start} → {iter_end} "
+                f"(recent window — likely publication lag)"
+            )
         gh_endgroup()
         n += 1
         current = next_first


### PR DESCRIPTION
## Summary

Package 2 from the 2026-06 deep-dive audit: the family of "pipeline goes green while losing data" bugs. No change to load semantics for healthy runs — every fix converts a silent failure into a visible one.

| # | Before | After |
|---|--------|-------|
| 1 | DB error in `get_latest_date` → `1970-01-01`, exit 0 → from-scratch re-extraction window | Raises `LatestDateQueryError` / exit 2 → job fails loudly; epoch fallback reserved for a *successful* query on an empty table |
| 2 | 100%-invalid JSONL (schema drift) → "success", file deleted, window re-extracts forever | All 8 insert paths return `False` when `total>0, valid==0, invalid>0` → `load-data` exits 1, run fails, **file preserved** |
| 3 | OCCTO load silently skipped if the guessed filename didn't match | Glob like the ENTSOE branch; missing output for a >2-day-old chunk raises, recent windows warn (publication lag) |
| 4 | `rebuild-npp-crosswalk` failures never opened a GitHub issue (missing from `notify-failure.needs`) | Added to the needs list |
| 5 | `logger.error("...", error=str(e))` — loguru drops kwargs, so the actual error text never reached any log | All structlog-style kwarg sites in `database.py` converted to f-strings (incl. the `insert_extraction_metadata` error path — fixed in a review follow-up commit) |

## Notes

- All-in-batch-duplicate files (valid 0, invalid 0) still count as success — only validation failures trip fix 2.
- Exit-code path traced end-to-end: `insert_*` → `load_data` → `sys.exit(0 if success else 1)` → workflow step → `notify-failure`. In `incremental_extract`, `run(check=True)` raises before `jsonl.unlink()`, so failed files survive for debugging.
- `resolve-window` runs `set -euo pipefail`, so exit 2 from fix 1 fails the step rather than being captured into `START_DATE`.
- Fix 1 in-process caller (`incremental_extract.resume_from`) does not catch `LatestDateQueryError` — it propagates to a non-zero exit, which is the intended loud failure (no more silent 1970 → re-extract from 2019).

## Deferred to follow-up PRs (design decisions, not mechanical fixes)

- Trailing-lookback resume window (closes per-plant-lag / month-boundary gaps; changes weekly extraction cost)
- `ON CONFLICT DO UPDATE` for source revisions (currently revisions can never reach the DB)

## Verification

45 tests pass · ruff check + format clean · workflow YAML parses · `py_compile` on all touched modules. Manually driven end-to-end against a local Postgres (verify session): healthy load, 100%-invalid → exit 1 + 0 rows, all-duplicate → exit 0, empty → exit 0, DB-unreachable → exit 2, OCCTO renamed-output glob, OCCTO missing-output past→raise / recent→warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)