### PR TITLE
fix: drop 'Actual Consumption' rows at ENTSOE load (consumption-as-generation bug)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -610,11 +610,26 @@ class PowerGenerationDatabase:
             # Process file in batches
             with open(jsonl_file_path, "r") as f:
                 batch = []
+                consumption_skipped = 0
                 for line_num, line in enumerate(f, 1):
                     if not line.strip():
                         continue
 
                     record = json.loads(line)
+
+                    # This is a GENERATION table. ENTSO-E per-plant responses
+                    # also carry 'Actual Consumption' series (a plant's own
+                    # draw / pumping load, ~0 for fossil), and the natural key
+                    # (ts, country, psr, plant) does NOT include data_type —
+                    # so a consumption row that arrives first permanently
+                    # displaces the real generation row at the same key
+                    # (in-batch dedup keeps first; ON CONFLICT DO NOTHING
+                    # keeps existing). Observed: IE/GB_NIR/PT histories were
+                    # consumption-dominated zeros. Drop them at the door.
+                    # Legacy values ('Unknown', fuel names) pass through.
+                    if record.get("data_type") == "Actual Consumption":
+                        consumption_skipped += 1
+                        continue
 
                     # Add extraction metadata if not present
                     if "extraction_run_id" not in record:
@@ -713,6 +728,12 @@ class PowerGenerationDatabase:
                     total_valid += valid
                     total_invalid += invalid
                     total_duplicate += dup
+
+            if consumption_skipped:
+                logger.info(
+                    f"Dropped {consumption_skipped:,} 'Actual Consumption' "
+                    f"records (generation table stores 'Actual Aggregated' only)"
+                )
 
             # Create aggregate validation report
             report = ValidationReport(

--- a/tests/test_entsoe_consumption_filter.py
+++ b/tests/test_entsoe_consumption_filter.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""ENTSOE loads must drop 'Actual Consumption' rows at the door.
+
+The natural key (timestamp_ms, country_code, psr_type, plant_name) omits
+data_type, so a consumption row (value ~0) that arrives before the matching
+generation row permanently displaces it: in-batch dedup keeps first, and
+ON CONFLICT DO NOTHING keeps existing. Observed in production: the IE,
+GB_NIR and PT histories were consumption-dominated zeros.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from database import PowerGenerationDatabase
+
+
+def _record(plant: str, data_type: str, ts: int = 1746057600000) -> dict:
+    return {
+        "extraction_run_id": "11111111-2222-3333-4444-555555555555",
+        "created_at_ms": 1746057600000,
+        "timestamp_ms": ts,
+        "country_code": "IE",
+        "psr_type": "B04",
+        "plant_name": plant,
+        "fuel_type": "Fossil Gas",
+        "data_type": data_type,
+        "generation_mw": 0.0 if data_type == "Actual Consumption" else 123.0,
+        "resolution_minutes": 30,
+    }
+
+
+def _db_with_captured_batches(monkeypatch):
+    db = PowerGenerationDatabase(
+        host="localhost", port=5432, database="x", username="x", password="x"
+    )
+    captured = []
+
+    def fake_batch(batch, expected_columns, validator, batch_num, *a, **k):
+        valid, report = validator.validate_file(batch, "entsoe", "test")
+        captured.extend(valid)
+        return (
+            len(valid),
+            report.valid_count,
+            report.invalid_count,
+            report.duplicate_count,
+        )
+
+    monkeypatch.setattr(db, "_insert_entsoe_batch", fake_batch)
+    monkeypatch.setattr(db, "_get_date_range_for_run", lambda *a, **k: (None, None))
+    monkeypatch.setattr(db, "insert_extraction_metadata", lambda *a, **k: True)
+    return db, captured
+
+
+def test_consumption_rows_never_reach_the_insert(monkeypatch):
+    db, captured = _db_with_captured_batches(monkeypatch)
+    records = [
+        _record("Plant A", "Actual Consumption"),  # would displace Plant A's
+        _record("Plant A", "Actual Aggregated"),  # generation without the filter
+        _record("Plant B", "Actual Aggregated"),
+        _record("Plant B", "Actual Consumption"),
+    ]
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+        path = f.name
+
+    ok, report = db.insert_entsoe_jsonl_data(path)
+    assert ok is True
+    assert len(captured) == 2, "exactly the two Aggregated rows must be inserted"
+    assert {r["data_type"] for r in captured} == {"Actual Aggregated"}
+    assert all(r["generation_mw"] == 123.0 for r in captured), (
+        "the surviving rows must be the real generation values, not the zeros"
+    )
+
+
+def test_consumption_only_file_is_a_clean_noop(monkeypatch):
+    db, captured = _db_with_captured_batches(monkeypatch)
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for i in range(5):
+            f.write(json.dumps(_record(f"P{i}", "Actual Consumption")) + "\n")
+        path = f.name
+
+    ok, report = db.insert_entsoe_jsonl_data(path)
+    assert ok is True, "nothing-to-load is success, not failure"
+    assert captured == []
+
+
+def test_legacy_data_types_pass_through(monkeypatch):
+    db, captured = _db_with_captured_batches(monkeypatch)
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        f.write(json.dumps(_record("Old Plant", "Unknown")) + "\n")
+        path = f.name
+
+    ok, _ = db.insert_entsoe_jsonl_data(path)
+    assert ok is True
+    assert len(captured) == 1 and captured[0]["data_type"] == "Unknown"


### PR DESCRIPTION
## Why

The entsoe natural key omits `data_type`, ENTSO-E per-plant responses carry **both** `Actual Aggregated` (generation) and `Actual Consumption` (~0 for fossil) series, and consumption precedes generation in extractor output — so keep-first dedup stores the **zero-valued consumption row** and the real generation row is silently dropped forever (`ON CONFLICT DO NOTHING` keeps the wrong row).

Production impact found while backfilling the ENTSOE country gaps: **IE (2.45M rows), GB_NIR (1.46M), PT (0.67M) are consumption-dominated** — their per-plant generation histories are mostly zeros — with material contamination in FR (0.79M) and HU (0.36M).

## Fix

`insert_entsoe_jsonl_data` drops `data_type == 'Actual Consumption'` before validation/batching (count logged). Legacy values (`'Unknown'`, fuel names) pass through. A consumption-only file is a clean no-op success.

## Tests

3 new unit tests (DB calls monkeypatched, validator real): mixed file inserts only the generation values; consumption-only file is a no-op success; legacy `data_type` passes through. 48 total pass; ruff clean.

## Companion operational fix (after merge, not in this PR)

Delete the ~5.7M stored consumption rows, then re-extract IE/GB_NIR/PT full histories + FR/HU/IT affected windows (~396 zone-months) — the displaced generation rows were dropped at **load** time and are not in the DB. Delete must precede reload or the occupied keys block the real rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)