### PR TITLE
fix: complete two half-applied ETL fixes (post-fix deep-dive)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1125,6 +1125,11 @@ class PowerGenerationDatabase:
             total_duplicates = 0
             total_records = 0
             chunk_num = 0
+            # The id the INSERTED rows actually carry: *_etl.jsonl files include
+            # their own extraction_run_id (kept below), so metadata must be
+            # keyed to it, not the local uuid4 — otherwise
+            # _get_date_range_for_run matches 0 rows and start/end go NULL.
+            file_run_id = None
 
             with open(jsonl_file_path, "r") as f:
                 while True:
@@ -1146,6 +1151,10 @@ class PowerGenerationDatabase:
                     # Add extraction metadata
                     has_extraction_run_id = "extraction_run_id" in chunk[0]
                     has_created_at_ms = "created_at_ms" in chunk[0]
+                    if file_run_id is None:
+                        file_run_id = chunk[0].get(
+                            "extraction_run_id", extraction_run_id
+                        )
 
                     for record in chunk:
                         if not has_extraction_run_id:
@@ -1196,11 +1205,12 @@ class PowerGenerationDatabase:
                 logger.warning(f"Skipped duplicate records: {total_duplicates}")
 
             if total_inserted > 0:
+                data_run_id = file_run_id or extraction_run_id
                 start_date, end_date = self._get_date_range_for_run(
-                    "ons_generation_data", extraction_run_id
+                    "ons_generation_data", data_run_id
                 )
                 self.insert_extraction_metadata(
-                    extraction_run_id=extraction_run_id,
+                    extraction_run_id=data_run_id,
                     source="ons",
                     extraction_timestamp=datetime.now(),
                     start_date=start_date,
@@ -1579,6 +1589,7 @@ class PowerGenerationDatabase:
             "oe_generation_data",
             "oe_facility_generation_data",
             "occto_generation_data",
+            "chile_generation_data",
         ]
         counts = {}
 
@@ -1587,8 +1598,11 @@ class PowerGenerationDatabase:
                 with self.engine.connect() as conn:
                     result = conn.execute(text(f"SELECT COUNT(*) FROM {table}"))
                     counts[table] = result.scalar()
-            except Exception:
-                counts[table] = 0
+            except Exception as e:
+                # None, not 0: a query failure must be distinguishable from a
+                # genuinely empty table in `stats` output.
+                logger.error(f"Failed to count {table}: {e}")
+                counts[table] = None
 
         return counts
 
@@ -1663,6 +1677,9 @@ class PowerGenerationDatabase:
             total_duplicates = 0
             total_records = 0
             chunk_num = 0
+            # See ONS: metadata must key to the run id the inserted rows carry
+            # (from the *_etl.jsonl file), not the local uuid4.
+            file_run_id = None
 
             with open(jsonl_file_path, "r") as f:
                 while True:
@@ -1689,6 +1706,10 @@ class PowerGenerationDatabase:
                     # Add extraction metadata if absent
                     has_extraction_run_id = "extraction_run_id" in chunk[0]
                     has_created_at_ms = "created_at_ms" in chunk[0]
+                    if file_run_id is None:
+                        file_run_id = chunk[0].get(
+                            "extraction_run_id", extraction_run_id
+                        )
 
                     for record in chunk:
                         if not has_extraction_run_id:
@@ -1744,11 +1765,12 @@ class PowerGenerationDatabase:
                 logger.warning(f"Skipped duplicate records: {total_duplicates}")
 
             if total_inserted > 0:
+                data_run_id = file_run_id or extraction_run_id
                 start_date, end_date = self._get_date_range_for_run(
-                    "chile_generation_data", extraction_run_id
+                    "chile_generation_data", data_run_id
                 )
                 self.insert_extraction_metadata(
-                    extraction_run_id=extraction_run_id,
+                    extraction_run_id=data_run_id,
                     source="chile",
                     extraction_timestamp=datetime.now(),
                     start_date=start_date,

--- a/src/database.py
+++ b/src/database.py
@@ -1579,7 +1579,7 @@ class PowerGenerationDatabase:
             logger.error(f"Failed to get record count for {table_name}: {e}")
             return 0
 
-    def get_all_record_counts(self) -> Dict[str, int]:
+    def get_all_record_counts(self) -> Dict[str, Optional[int]]:
         """Get record counts for all main tables."""
         tables = [
             "npp_generation",

--- a/src/database.py
+++ b/src/database.py
@@ -684,10 +684,23 @@ class PowerGenerationDatabase:
 
                     # Clean plant_name: strip leaked fuel-type and data-type suffixes
                     plant_name = record.get("plant_name", "")
+                    consumption_via_suffix = False
                     for suffix in _DATA_TYPE_SUFFIXES:
                         if plant_name.endswith("_" + suffix):
+                            # Legacy format: data_type leaked into plant_name and
+                            # the data_type field is "Unknown"/a fuel name, so the
+                            # line-630 filter misses it. Stripping "_Actual
+                            # Consumption" here would collapse the name onto its
+                            # "_Actual Aggregated" sibling and displace real
+                            # generation at the shared natural key — the same bug
+                            # the field-level filter above prevents. Drop it too.
+                            if suffix == "Actual Consumption":
+                                consumption_via_suffix = True
                             plant_name = plant_name[: -(len(suffix) + 1)]
                             break
+                    if consumption_via_suffix:
+                        consumption_skipped += 1
+                        continue
                     for suffix in _FUEL_TYPE_SUFFIXES:
                         if plant_name.endswith("_" + suffix):
                             plant_name = plant_name[: -(len(suffix) + 1)]

--- a/src/database_management.py
+++ b/src/database_management.py
@@ -192,11 +192,14 @@ def show_database_stats():
         return False
 
     counts = db.get_all_record_counts()
-    total_records = sum(counts.values())
+    # A failed count is None (distinct from an empty table's 0) — skip it in
+    # the total and show ERROR rather than crashing sum()/format on None.
+    total_records = sum(c for c in counts.values() if c is not None)
 
     logger.info(f"Total records across all tables: {total_records:,}")
     for table, count in counts.items():
-        logger.info(f"  {table}: {count:,} records")
+        shown = "ERROR" if count is None else f"{count:,}"
+        logger.info(f"  {table}: {shown} records")
 
     db.close()
     return True

--- a/src/incremental_extract.py
+++ b/src/incremental_extract.py
@@ -153,8 +153,26 @@ def extract_entsoe() -> int:
             ],
             env=env,
         )
-        for f in sorted(EXTRACTED_DATA.glob("entsoe_*_etl.jsonl")):
-            load_and_remove("entsoe", f)
+        entsoe_files = sorted(EXTRACTED_DATA.glob("entsoe_*_etl.jsonl"))
+        if entsoe_files:
+            for f in entsoe_files:
+                load_and_remove("entsoe", f)
+        elif current < today.replace(day=1):
+            # Same guard as the OCCTO branch: a fully-past month must produce
+            # output. An empty glob there means extraction went green but
+            # loaded nothing — latest_date never advances and the same month
+            # re-extracts forever, silently. Only the current month may be
+            # legitimately empty (publication lag / month just started).
+            raise RuntimeError(
+                f"ENTSOE extraction for {current.year}-{current.month:02d} "
+                f"succeeded but produced no entsoe_*_etl.jsonl in "
+                f"{EXTRACTED_DATA} — output naming may have changed"
+            )
+        else:
+            logger.warning(
+                f"No ENTSOE output for {current.year}-{current.month:02d} "
+                f"(current month — likely publication lag)"
+            )
         gh_endgroup()
         n += 1
         current = add_months(current, 1)

--- a/tests/test_entsoe_consumption_filter.py
+++ b/tests/test_entsoe_consumption_filter.py
@@ -98,3 +98,26 @@ def test_legacy_data_types_pass_through(monkeypatch):
     ok, _ = db.insert_entsoe_jsonl_data(path)
     assert ok is True
     assert len(captured) == 1 and captured[0]["data_type"] == "Unknown"
+
+
+def test_legacy_consumption_suffix_is_dropped(monkeypatch):
+    """Legacy format: data_type leaked into plant_name as a suffix while the
+    data_type FIELD is 'Unknown'. The field-level filter misses it, but
+    stripping '_Actual Consumption' would collapse it onto the generation
+    sibling's key and displace it. It must be dropped at the suffix step."""
+    db, captured = _db_with_captured_batches(monkeypatch)
+    records = [
+        # legacy rows: field says 'Unknown', metric is in the plant_name suffix
+        {**_record("Plant A_Actual Consumption", "Unknown"), "generation_mw": 0.0},
+        {**_record("Plant A_Actual Aggregated", "Unknown"), "generation_mw": 123.0},
+    ]
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+        path = f.name
+
+    ok, _ = db.insert_entsoe_jsonl_data(path)
+    assert ok is True
+    assert len(captured) == 1, "only the aggregated row survives"
+    assert captured[0]["plant_name"] == "Plant A", "suffix stripped to bare name"
+    assert captured[0]["generation_mw"] == 123.0, "real generation kept, not the zero"

--- a/tests/test_incremental_extract.py
+++ b/tests/test_incremental_extract.py
@@ -98,3 +98,33 @@ class TestWarnIfLongWindow:
     def test_threshold_constant_is_12(self):
         # Sanity check the documented soft ceiling.
         assert LONG_WINDOW_MONTHS == 12
+
+
+class TestEntsoeEmptyOutputGuard:
+    """A fully-past ENTSOE month that produces no JSONL must raise, mirroring
+    the OCCTO guard — otherwise the job goes green, latest_date never advances,
+    and the same month re-extracts forever loading nothing."""
+
+    def _run_entsoe(self, monkeypatch, tmp_path, start, end):
+        import incremental_extract as ie
+
+        monkeypatch.setenv("START_OVERRIDE", start)
+        monkeypatch.setenv("END_OVERRIDE", end)
+        monkeypatch.setattr(ie, "EXTRACTED_DATA", tmp_path)
+        # subprocess is a no-op: simulates extraction that writes nothing
+        monkeypatch.setattr(ie, "run", lambda *a, **k: None)
+        return ie.extract_entsoe()
+
+    def test_past_month_with_no_output_raises(self, monkeypatch, tmp_path):
+        with pytest.raises(RuntimeError, match="produced no entsoe_"):
+            self._run_entsoe(monkeypatch, tmp_path, "2025-01-01", "2025-01-01")
+
+    def test_current_month_with_no_output_only_warns(
+        self, monkeypatch, tmp_path, loguru_messages
+    ):
+        today = date.today()
+        first = today.replace(day=1).isoformat()
+        # current month, empty output → warn, no raise, returns 1 iteration
+        n = self._run_entsoe(monkeypatch, tmp_path, first, first)
+        assert n == 1
+        assert any("publication lag" in m for m in loguru_messages)

--- a/tests/test_metadata_run_id.py
+++ b/tests/test_metadata_run_id.py
@@ -103,3 +103,23 @@ def test_get_all_record_counts_includes_chile():
 
     src = inspect.getsource(PowerGenerationDatabase.get_all_record_counts)
     assert "chile_generation_data" in src
+
+
+def test_stats_survives_none_count(monkeypatch):
+    """A failed per-table count is None; the `stats` command must not crash
+    on sum()/format (the change that introduced None shipped without this)."""
+    import database_management as dm
+
+    db = PowerGenerationDatabase(
+        host="localhost", port=5432, database="x", username="x", password="x"
+    )
+    monkeypatch.setattr(db, "test_connection", lambda: True)
+    monkeypatch.setattr(db, "close", lambda: None)
+    monkeypatch.setattr(
+        db,
+        "get_all_record_counts",
+        lambda: {"npp_generation": 5, "chile_generation_data": None},
+    )
+    monkeypatch.setattr(dm, "create_power_generation_database", lambda: db)
+    # must return True without raising TypeError on the None count
+    assert dm.show_database_stats() is True

--- a/tests/test_metadata_run_id.py
+++ b/tests/test_metadata_run_id.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""ONS/Chile extraction metadata must be keyed to the run-id the inserted
+rows actually carry (from the *_etl.jsonl file), not a fresh local uuid4.
+
+Bug: both methods generated a local uuid4 and used it for both
+_get_date_range_for_run and insert_extraction_metadata, while the rows kept
+the file's id — so the date-range lookup matched 0 rows (NULL start/end) and
+the metadata row pointed at no data. ENTSOE/NPP/EIA/OE already key to the
+file's id; this pins ONS/Chile to the same behavior.
+"""
+
+import json
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from database import PowerGenerationDatabase
+
+FILE_RUN_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _ons_record(i: int) -> dict:
+    return {
+        "extraction_run_id": FILE_RUN_ID,
+        "created_at_ms": 1746057600000,
+        "timestamp_ms": 1746057600000 + i * 3600000,
+        "plant": f"Plant {i}",
+        "ons_plant_id": f"P{i}",
+        "fuel_type": "Carvão",
+        "generation_mwh": 10.0 + i,
+        "resolution_minutes": 60,
+    }
+
+
+def _chile_record(i: int) -> dict:
+    return {
+        "extraction_run_id": FILE_RUN_ID,
+        "created_at_ms": 1746057600000,
+        "timestamp_ms": 1746057600000 + i * 3600000,
+        "plant": f"Central {i}",
+        "chile_plant_id": f"C{i}",
+        "fuel_type": "Carbón",
+        "generation_mwh": 5.0 + i,
+        "resolution_minutes": 60,
+    }
+
+
+def _run(monkeypatch, insert_fn, recs):
+    db = PowerGenerationDatabase(
+        host="localhost", port=5432, database="x", username="x", password="x"
+    )
+    captured = {}
+    # report inserts without a DB
+    monkeypatch.setattr(db, "_execute_with_retry", lambda fn: len(recs))
+
+    def fake_date_range(table, run_id):
+        captured["date_run_id"] = run_id
+        return (None, None)
+
+    def fake_meta(**kw):
+        captured["meta_run_id"] = kw["extraction_run_id"]
+        return True
+
+    monkeypatch.setattr(db, "_get_date_range_for_run", fake_date_range)
+    monkeypatch.setattr(db, "insert_extraction_metadata", fake_meta)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+        path = f.name
+    insert_fn(db)(path)
+    return captured
+
+
+def test_ons_metadata_uses_file_run_id(monkeypatch):
+    cap = _run(
+        monkeypatch,
+        lambda db: db.insert_ons_jsonl_data,
+        [_ons_record(i) for i in range(3)],
+    )
+    assert cap["meta_run_id"] == FILE_RUN_ID
+    assert cap["date_run_id"] == FILE_RUN_ID
+    assert uuid.UUID(cap["meta_run_id"])  # well-formed
+
+
+def test_chile_metadata_uses_file_run_id(monkeypatch):
+    cap = _run(
+        monkeypatch,
+        lambda db: db.insert_chile_jsonl_data,
+        [_chile_record(i) for i in range(3)],
+    )
+    assert cap["meta_run_id"] == FILE_RUN_ID
+    assert cap["date_run_id"] == FILE_RUN_ID
+
+
+def test_get_all_record_counts_includes_chile():
+    # static check: the table list must cover chile (was omitted)
+    import inspect
+
+    src = inspect.getsource(PowerGenerationDatabase.get_all_record_counts)
+    assert "chile_generation_data" in src


### PR DESCRIPTION
Found by a full post-fix deep-dive (independent cold auditors). Both are **half-applied fixes** — a guard/filter on one path but not its sibling.

**ETL-1 — ENTSOE empty-output guard.** The OCCTO branch raises when a fully-past chunk produces no JSONL ("a silent naming change must not mean extraction-green/nothing-loaded forever"), but the ENTSOE branch it cites just globbed and looped — so the largest source had exactly that silent-failure mode (latest_date never advances, same month re-extracts forever). Added the matching guard: a month strictly before the current calendar month with no output raises; the current month only warns. Uses real `today`, so END_OVERRIDE backfills of past months are still guarded.

**ETL-2 — legacy consumption suffix.** The Actual-Consumption door filter (PR #26) checks only the modern `data_type` field, but the adjacent suffix-strip code strips `"_Actual Consumption"` off `plant_name` for legacy-format rows (field = `"Unknown"`), collapsing the name onto its `"_Actual Aggregated"` sibling and re-creating the displacement bug at the shared natural key. Now drops the record when the stripped suffix is Actual Consumption.

3 new tests; 51 pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)