### PR TITLE
feat: Climate TRACE loader — first revision-aware (ON CONFLICT DO UPDATE) source

### DIFF
--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -33,6 +33,7 @@ on:
           - 'OE (Australia)'
           - 'OCCTO (Japan)'
           - 'Chile (Coordinador)'
+          - 'Climate TRACE (global)'
       start_override:
         description: 'Re-run window start (YYYY-MM-DD). Leave blank for default (latest in DB).'
         required: false
@@ -541,6 +542,74 @@ jobs:
           retention-days: 14
 
   # ─────────────────────────────────────────────
+  # Climate TRACE (global, MODELED generation). No incremental window: the
+  # source ships one bulk package covering 2021→now (~8s to process), and it
+  # REVISES past months between releases — so every run re-extracts the full
+  # history and the loader upserts (ON CONFLICT DO UPDATE) so revisions
+  # propagate. Steady state writes only new months + genuine revisions.
+  # High-confidence-only by default (extractor --min-confidence high).
+  # No credentials required — the download bucket is public.
+  # ─────────────────────────────────────────────
+  extract-climatetrace:
+    if: ${{ github.event.inputs.source == '' || github.event.inputs.source == 'all' || github.event.inputs.source == 'Climate TRACE (global)' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: extract-climatetrace
+      cancel-in-progress: false
+    steps:
+      - name: Checkout ETL repo
+        uses: actions/checkout@v4
+
+      - name: Checkout extractors repo
+        uses: actions/checkout@v4
+        with:
+          repository: nicholas-abad/energy-extractors
+          path: extractors
+          token: ${{ secrets.EXTRACTORS_REPO_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install ETL dependencies
+        run: uv sync
+
+      - name: Install extractor dependencies
+        run: |
+          cd extractors
+          uv sync
+
+      - name: Extract Climate TRACE data (full history, high confidence)
+        run: |
+          cd extractors
+          uv run energy-extract climatetrace \
+            --output ../extracted_data \
+            --log-level INFO
+
+      - name: Load Climate TRACE data into Neon
+        run: |
+          for f in extracted_data/climatetrace_*_etl.jsonl; do
+            echo "Loading $f..."
+            uv run python src/database_management.py load-data climatetrace "$f"
+          done
+
+      - name: Upload artifacts (on failure only)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: climatetrace-extraction-${{ github.run_id }}
+          path: |
+            extracted_data/*.jsonl
+            extracted_data/logs/
+            extracted_data/extraction_metadata_*.json
+          retention-days: 14
+
+  # ─────────────────────────────────────────────
   # Rebuild the NPP plant_crosswalk after extraction so newly-appearing plants
   # get coal_type / coordinates. The dashboard classifies NPP coal via
   # plant_crosswalk.coal_type (joined by plant name), so without this a new coal
@@ -751,7 +820,7 @@ jobs:
   # Notify on failure — create GitHub Issue
   # ─────────────────────────────────────────────
   notify-failure:
-    needs: [extract-eia, extract-ons, extract-entsoe, extract-npp, extract-oe, extract-occto, extract-chile, rebuild-npp-crosswalk, refresh-views, check-crosswalk-drift]
+    needs: [extract-eia, extract-ons, extract-entsoe, extract-npp, extract-oe, extract-occto, extract-chile, extract-climatetrace, rebuild-npp-crosswalk, refresh-views, check-crosswalk-drift]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
@@ -767,8 +836,10 @@ jobs:
               'extract-oe': '${{ needs.extract-oe.result }}',
               'extract-occto': '${{ needs.extract-occto.result }}',
               'extract-chile': '${{ needs.extract-chile.result }}',
+              'extract-climatetrace': '${{ needs.extract-climatetrace.result }}',
               'refresh-views': '${{ needs.refresh-views.result }}',
               'check-crosswalk-drift': '${{ needs.check-crosswalk-drift.result }}',
+              'rebuild-npp-crosswalk': '${{ needs.rebuild-npp-crosswalk.result }}',
             };
             const failed = Object.entries(jobs)
               .filter(([_, v]) => v === 'failure')

--- a/schema/climatetrace_generation.sql
+++ b/schema/climatetrace_generation.sql
@@ -1,0 +1,61 @@
+-- Climate TRACE Power Generation Data (global, MODELED)
+-- Monthly per-plant generation + emissions estimates from the Climate TRACE
+-- bulk download packages (satellite + ML estimates, NOT metered readings —
+-- unlike every other source table). By default only plant-months whose
+-- generation estimate Climate TRACE rates 'high'+ are extracted (~2.5K
+-- plants globally, the reported-data-backed subset).
+-- One table for ALL countries (country_code column), mirroring how
+-- entsoe_generation holds ~30 countries — do not split per country.
+-- Data source: https://downloads.climatetrace.org
+
+CREATE TABLE IF NOT EXISTS climatetrace_generation_data (
+    id BIGSERIAL PRIMARY KEY,
+
+    -- Extraction metadata
+    extraction_run_id UUID NOT NULL,
+    created_at_ms BIGINT NOT NULL,
+
+    -- Plant identification (climatetrace_id is Climate TRACE's stable
+    -- source_id; names can collide across countries)
+    climatetrace_id VARCHAR(100) NOT NULL,
+    plant_name TEXT NOT NULL,
+    country_code VARCHAR(3) NOT NULL,        -- ISO-3166 alpha-3, e.g. 'CHN'
+    fuel_type VARCHAR(100),                  -- source_type; mixed like 'gas, coal'
+
+    -- Location (Climate TRACE ships coordinates — unlike other sources,
+    -- no plant_crosswalk join is needed for mapping)
+    latitude DOUBLE PRECISION,
+    longitude DOUBLE PRECISION,
+
+    -- Time series data (calendar-month grain; timestamp = month start UTC)
+    timestamp_ms BIGINT NOT NULL,
+    generation_mwh DOUBLE PRECISION NOT NULL,
+    capacity_mw DOUBLE PRECISION,
+    capacity_factor DOUBLE PRECISION,        -- 0..1 ratio
+    activity_confidence VARCHAR(20),         -- Climate TRACE's rating of generation_mwh
+
+    -- Emissions (denominated in `gas`, plant-specific factor)
+    emissions_tonnes DOUBLE PRECISION,
+    emissions_factor DOUBLE PRECISION,       -- t of <gas> per MWh
+    gas VARCHAR(30),                         -- e.g. 'co2e_100yr'
+
+    -- Provenance: the package release each value came from. Climate TRACE
+    -- REVISES history between releases; the loader upserts (ON CONFLICT DO
+    -- UPDATE) so revisions propagate, and ct_version records which release
+    -- a row currently reflects.
+    ct_version VARCHAR(20),
+
+    -- Data quality constraints
+    CONSTRAINT valid_timestamps_climatetrace CHECK (timestamp_ms > 0 AND created_at_ms > 0),
+    CONSTRAINT non_negative_generation_climatetrace CHECK (generation_mwh >= 0)
+);
+
+-- Natural key uniqueness — also the upsert conflict target.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_climatetrace_natural_key
+ON climatetrace_generation_data (climatetrace_id, timestamp_ms);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_climatetrace_country_time ON climatetrace_generation_data (country_code, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_climatetrace_fuel_time ON climatetrace_generation_data (fuel_type, timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_climatetrace_timestamp ON climatetrace_generation_data (timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_climatetrace_extraction_run ON climatetrace_generation_data (extraction_run_id);

--- a/src/database.py
+++ b/src/database.py
@@ -127,6 +127,7 @@ _KNOWN_TABLES = frozenset(
         "oe_facility_generation_data",
         "occto_generation_data",
         "chile_generation_data",
+        "climatetrace_generation_data",
         "extraction_metadata",
         "plant_crosswalk",
         "eia_generator_info",
@@ -225,6 +226,7 @@ class PowerGenerationDatabase:
         target_table: str,
         conflict_columns: list = None,
         conflict_expr: str = None,
+        update_columns: list = None,
     ) -> int:
         """Insert rows via a staging table, skipping duplicates on conflict.
 
@@ -243,9 +245,17 @@ class PowerGenerationDatabase:
                 (used when the conflict target is plain columns).
             conflict_expr: Raw SQL expression for the ON CONFLICT target when
                 the unique index uses expressions (e.g. COALESCE).
+            update_columns: If given, conflicts DO UPDATE these columns from
+                the incoming row instead of being skipped — for sources that
+                REVISE history (Climate TRACE re-states past months every
+                release; DO NOTHING would freeze the first-loaded values
+                forever). Rows whose incoming values are identical are left
+                untouched (IS DISTINCT FROM guard), so a re-load of unchanged
+                data writes nothing and the return value stays meaningful.
 
         Returns:
-            Number of rows actually inserted (excluding duplicates).
+            Number of rows written: inserted (plus genuinely updated when
+            ``update_columns`` is set); no-op duplicates are never counted.
         """
         if (conflict_columns is None) == (conflict_expr is None):
             raise ValueError(
@@ -268,6 +278,21 @@ class PowerGenerationDatabase:
                 _validate_identifier(col)
             conflict_target = f"({', '.join(conflict_columns)})"
 
+        if update_columns:
+            for col in update_columns:
+                _validate_identifier(col)
+            set_list = ", ".join(f"{c} = EXCLUDED.{c}" for c in update_columns)
+            t_tuple = ", ".join(f"t.{c}" for c in update_columns)
+            e_tuple = ", ".join(f"EXCLUDED.{c}" for c in update_columns)
+            conflict_action = (
+                f"DO UPDATE SET {set_list} "
+                f"WHERE ({t_tuple}) IS DISTINCT FROM ({e_tuple})"
+            )
+            insert_target = f"{target_table} AS t"
+        else:
+            conflict_action = "DO NOTHING"
+            insert_target = target_table
+
         conn = self.engine.raw_connection()
         try:
             cursor = conn.cursor()
@@ -285,11 +310,12 @@ class PowerGenerationDatabase:
             output.seek(0)
             cursor.copy_from(output, staging, columns=columns, sep="\t", null="\\N")
 
-            # 3. INSERT from staging into target, skipping duplicates
+            # 3. INSERT from staging into target; conflicts are skipped
+            # (DO NOTHING) or, with update_columns, revised in place.
             cursor.execute(
-                f"INSERT INTO {target_table} ({col_list}) "
+                f"INSERT INTO {insert_target} ({col_list}) "
                 f"SELECT {col_list} FROM {staging} "
-                f"ON CONFLICT {conflict_target} DO NOTHING"
+                f"ON CONFLICT {conflict_target} {conflict_action}"
             )
             inserted = cursor.rowcount
 
@@ -413,6 +439,10 @@ class PowerGenerationDatabase:
         """Create Chile (Coordinador) generation table."""
         return self._execute_schema_file("chile_generation.sql")
 
+    def create_climatetrace_table(self) -> bool:
+        """Create the Climate TRACE (global, modeled) generation table."""
+        return self._execute_schema_file("climatetrace_generation.sql")
+
     def create_extraction_metadata_table(self) -> bool:
         """Create extraction metadata table."""
         return self._execute_schema_file("extraction_metadata.sql")
@@ -429,6 +459,7 @@ class PowerGenerationDatabase:
             "oe_facility",
             "occto",
             "chile",
+            "climatetrace",
             "extraction_metadata",
         ]:
             try:
@@ -1590,6 +1621,7 @@ class PowerGenerationDatabase:
             "oe_facility_generation_data",
             "occto_generation_data",
             "chile_generation_data",
+            "climatetrace_generation_data",
         ]
         counts = {}
 
@@ -1806,6 +1838,201 @@ class PowerGenerationDatabase:
 
         except Exception as e:
             logger.error(f"Failed to insert Chile data: {e}")
+            return False, None
+
+    def insert_climatetrace_jsonl_data(
+        self,
+        jsonl_file_path: str,
+        extraction_run_id: str = None,
+        validation_report_path: str = None,
+        chunk_lines: int = 50_000,
+    ) -> Tuple[bool, Optional[ValidationReport]]:
+        """Insert Climate TRACE data from JSONL file with validation.
+
+        Unlike every other source, this UPSERTS (ON CONFLICT DO UPDATE):
+        Climate TRACE revises past months between package releases, and each
+        weekly run re-states the full history — DO NOTHING would freeze the
+        first-loaded estimates forever. Unchanged rows are not rewritten
+        (IS DISTINCT FROM guard), so the weekly steady state writes only
+        genuinely new months and genuine revisions; ct_version records which
+        release each row currently reflects.
+
+        Returns:
+            Tuple of (success, validation_report)
+        """
+        try:
+            if extraction_run_id is None:
+                extraction_run_id = str(uuid.uuid4())
+            created_at_ms = int(datetime.now().timestamp() * 1000)
+
+            # Columns kept on insert (anything else from the JSONL is dropped).
+            keep_cols = [
+                "extraction_run_id",
+                "created_at_ms",
+                "climatetrace_id",
+                "plant_name",
+                "country_code",
+                "fuel_type",
+                "latitude",
+                "longitude",
+                "timestamp_ms",
+                "generation_mwh",
+                "capacity_mw",
+                "capacity_factor",
+                "activity_confidence",
+                "emissions_tonnes",
+                "emissions_factor",
+                "gas",
+                "ct_version",
+            ]
+            # Data columns revised in place on conflict. Deliberately NOT
+            # extraction_run_id/created_at_ms: an unchanged row keeps the
+            # provenance of the run that last CHANGED it, and including
+            # always-fresh bookkeeping fields in the update set would defeat
+            # the IS DISTINCT FROM no-op guard (every row would rewrite on
+            # every weekly run).
+            update_cols = [
+                "plant_name",
+                "country_code",
+                "fuel_type",
+                "latitude",
+                "longitude",
+                "generation_mwh",
+                "capacity_mw",
+                "capacity_factor",
+                "activity_confidence",
+                "emissions_tonnes",
+                "emissions_factor",
+                "gas",
+                "ct_version",
+            ]
+
+            validator = DataValidator()
+            total_inserted = 0
+            total_valid = 0
+            total_invalid = 0
+            total_duplicates = 0
+            total_records = 0
+            chunk_num = 0
+            # See ONS: metadata must key to the run id the inserted rows carry
+            # (from the *_etl.jsonl file), not the local uuid4.
+            file_run_id = None
+
+            with open(jsonl_file_path, "r") as f:
+                while True:
+                    chunk = []
+                    for _ in range(chunk_lines):
+                        line = f.readline()
+                        if not line:
+                            break
+                        line = line.strip()
+                        if line:
+                            chunk.append(json.loads(line))
+
+                    if not chunk:
+                        break
+
+                    chunk_num += 1
+
+                    if file_run_id is None:
+                        file_run_id = chunk[0].get(
+                            "extraction_run_id", extraction_run_id
+                        )
+
+                    for record in chunk:
+                        if "extraction_run_id" not in record:
+                            record["extraction_run_id"] = extraction_run_id
+                        if "created_at_ms" not in record:
+                            record["created_at_ms"] = created_at_ms
+
+                    # Validate chunk
+                    valid_records, report = validator.validate_file(
+                        chunk, "climatetrace", jsonl_file_path
+                    )
+
+                    total_records += report.total_count
+                    total_valid += report.valid_count
+                    total_invalid += report.invalid_count
+                    total_duplicates += report.duplicate_count
+
+                    # Upsert valid records (revisions update in place)
+                    if valid_records:
+                        df = pd.DataFrame(valid_records)
+                        df = df[[c for c in keep_cols if c in df.columns]]
+
+                        def _upsert_chunk():
+                            return self._upsert_via_staging(
+                                df,
+                                "climatetrace_generation_data",
+                                conflict_columns=["climatetrace_id", "timestamp_ms"],
+                                update_columns=update_cols,
+                            )
+
+                        inserted = self._execute_with_retry(_upsert_chunk)
+                        total_inserted += inserted
+
+                    logger.info(
+                        f"Chunk {chunk_num} done: {report.valid_count} valid, "
+                        f"{total_inserted} written so far (inserts + revisions)"
+                    )
+
+                    del chunk, valid_records
+
+            logger.info(
+                f"Validation complete: {total_valid}/{total_records} valid, "
+                f"{total_invalid} invalid, {total_duplicates} duplicates"
+            )
+            if total_invalid > 0:
+                logger.warning(f"Skipped invalid records: {total_invalid}")
+            if total_duplicates > 0:
+                logger.warning(f"Skipped duplicate records: {total_duplicates}")
+
+            if total_inserted > 0:
+                data_run_id = file_run_id or extraction_run_id
+                start_date, end_date = self._get_date_range_for_run(
+                    "climatetrace_generation_data", data_run_id
+                )
+                self.insert_extraction_metadata(
+                    extraction_run_id=data_run_id,
+                    source="climatetrace",
+                    extraction_timestamp=datetime.now(),
+                    start_date=start_date,
+                    end_date=end_date,
+                    total_records=total_valid,
+                    failed_count=total_invalid,
+                    success=True,
+                )
+                logger.success(
+                    f"Written Climate TRACE records (inserts + revisions): "
+                    f"{total_inserted}"
+                )
+            else:
+                # With the no-op guard, a re-load of an unchanged package
+                # legitimately writes 0 rows — that is success, not failure.
+                logger.info("No new or revised records (data unchanged)")
+
+            aggregate_report = ValidationReport(
+                source_file=jsonl_file_path,
+                total_count=total_records,
+                valid_count=total_valid,
+                invalid_count=total_invalid,
+                duplicate_count=total_duplicates,
+            )
+
+            if validation_report_path:
+                save_report(aggregate_report, validation_report_path)
+
+            if total_records > 0 and total_valid == 0 and total_invalid > 0:
+                logger.error(
+                    f"All {total_records} records failed validation - "
+                    "treating load as FAILED (extractor schema drift?)"
+                )
+                return False, aggregate_report
+
+            return True, aggregate_report
+
+        except Exception as e:
+            logger.error(f"Failed to insert Climate TRACE data: {e}")
             return False, None
 
     def insert_extraction_metadata(

--- a/src/database_management.py
+++ b/src/database_management.py
@@ -57,6 +57,8 @@ def setup_database(table_type: str = "all"):
         success = db.create_occto_table()
     elif table_type == "chile":
         success = db.create_chile_table()
+    elif table_type == "climatetrace":
+        success = db.create_climatetrace_table()
     else:
         logger.error(f"Unknown table type: {table_type}")
         return False
@@ -161,6 +163,10 @@ def load_data(
         )
     elif data_source == "chile":
         success, report = db.insert_chile_jsonl_data(
+            jsonl_file, validation_report_path=validation_report
+        )
+    elif data_source == "climatetrace":
+        success, report = db.insert_climatetrace_jsonl_data(
             jsonl_file, validation_report_path=validation_report
         )
     else:
@@ -303,6 +309,7 @@ Examples:
             "oe_facility",
             "occto",
             "chile",
+            "climatetrace",
         ],
         default="all",
         nargs="?",
@@ -337,7 +344,17 @@ Examples:
     )
     load_parser.add_argument(
         "data_source",
-        choices=["npp", "entsoe", "eia", "ons", "oe", "oe_facility", "occto", "chile"],
+        choices=[
+            "npp",
+            "entsoe",
+            "eia",
+            "ons",
+            "oe",
+            "oe_facility",
+            "occto",
+            "chile",
+            "climatetrace",
+        ],
         help="Type of data source",
     )
     load_parser.add_argument("jsonl_file", help="Path to JSONL file")

--- a/src/validator.py
+++ b/src/validator.py
@@ -275,6 +275,32 @@ CHILE_SCHEMA = {
     "duplicate_key": ("timestamp_ms", "plant", "chile_plant_id"),
 }
 
+CLIMATETRACE_SCHEMA = {
+    "required_fields": {
+        "extraction_run_id": {"type": "str", "validation": "uuid"},
+        "created_at_ms": {"type": "int", "validation": "positive_timestamp"},
+        "timestamp_ms": {"type": "int", "validation": "positive_timestamp"},
+        "climatetrace_id": {"type": "str", "validation": "non_empty"},
+        "plant_name": {"type": "str", "validation": "non_empty"},
+        "country_code": {"type": "str", "validation": "non_empty"},
+        "generation_mwh": {"type": "float", "validation": "non_negative"},
+    },
+    "optional_fields": {
+        "fuel_type": {"type": "str_or_null", "validation": None},
+        "latitude": {"type": "float_or_null", "validation": None},
+        "longitude": {"type": "float_or_null", "validation": None},
+        "capacity_mw": {"type": "float_or_null", "validation": None},
+        "capacity_factor": {"type": "float_or_null", "validation": None},
+        "activity_confidence": {"type": "str_or_null", "validation": None},
+        "emissions_tonnes": {"type": "float_or_null", "validation": None},
+        "emissions_factor": {"type": "float_or_null", "validation": None},
+        "gas": {"type": "str_or_null", "validation": None},
+        "ct_version": {"type": "str_or_null", "validation": None},
+    },
+    # Matches uq_climatetrace_natural_key — the upsert conflict target.
+    "duplicate_key": ("climatetrace_id", "timestamp_ms"),
+}
+
 
 class DataValidator:
     """Validates power generation data records."""
@@ -289,6 +315,7 @@ class DataValidator:
             "oe_facility": OE_FACILITY_SCHEMA,
             "occto": OCCTO_SCHEMA,
             "chile": CHILE_SCHEMA,
+            "climatetrace": CLIMATETRACE_SCHEMA,
         }
 
     def _is_valid_uuid(self, value: str) -> bool:
@@ -456,6 +483,10 @@ class DataValidator:
     def validate_chile_record(self, record: Dict[str, Any]) -> ValidationResult:
         """Validate a single Chile (Coordinador) record."""
         return self._validate_record(record, CHILE_SCHEMA)
+
+    def validate_climatetrace_record(self, record: Dict[str, Any]) -> ValidationResult:
+        """Validate a single Climate TRACE (global, modeled) record."""
+        return self._validate_record(record, CLIMATETRACE_SCHEMA)
 
     def _get_duplicate_key(
         self, record: Dict[str, Any], key_fields: Tuple[str, ...]

--- a/tests/test_climatetrace_loader.py
+++ b/tests/test_climatetrace_loader.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Climate TRACE loader: validation schema, revision-aware upsert, metadata.
+
+Climate TRACE is the first source that REVISES history between releases
+(every weekly package re-states 2021→now), so its loader upserts with
+ON CONFLICT DO UPDATE instead of the house-default DO NOTHING — with an
+IS DISTINCT FROM guard so unchanged rows are not rewritten. These tests pin:
+the validator schema, the generated upsert SQL, the update-column set
+(bookkeeping fields excluded, or the no-op guard would never fire), the
+file-run-id metadata convention, and zero-written == success semantics.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from database import PowerGenerationDatabase
+from validator import DataValidator
+
+FILE_RUN_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _record(i: int = 0, **overrides) -> dict:
+    base = {
+        "extraction_run_id": FILE_RUN_ID,
+        "created_at_ms": 1746057600000,
+        "climatetrace_id": f"254519{i:02d}",
+        "plant_name": f"Plant {i}",
+        "country_code": "CHN",
+        "fuel_type": "coal",
+        "latitude": 40.0 + i,
+        "longitude": 111.0 + i,
+        "timestamp_ms": 1609459200000 + i * 2678400000,
+        "generation_mwh": 100000.0 + i,
+        "capacity_mw": 1000.0,
+        "capacity_factor": 0.5,
+        "activity_confidence": "high",
+        "emissions_tonnes": 95000.0,
+        "emissions_factor": 0.95,
+        "gas": "co2e_100yr",
+        "ct_version": "v5_8_0",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- validator schema --------------------------------------------------------
+
+
+def test_valid_record_passes():
+    valid, report = DataValidator().validate_file([_record()], "climatetrace", "x")
+    assert report.valid_count == 1 and report.invalid_count == 0
+
+
+def test_negative_generation_rejected():
+    valid, report = DataValidator().validate_file(
+        [_record(generation_mwh=-5.0)], "climatetrace", "x"
+    )
+    assert report.invalid_count == 1
+
+
+def test_missing_natural_key_field_rejected():
+    rec = _record()
+    del rec["climatetrace_id"]
+    valid, report = DataValidator().validate_file([rec], "climatetrace", "x")
+    assert report.invalid_count == 1
+
+
+def test_duplicate_key_is_plant_month():
+    # Same (climatetrace_id, timestamp_ms) → duplicate, even if values differ.
+    recs = [_record(), _record(generation_mwh=42.0)]
+    valid, report = DataValidator().validate_file(recs, "climatetrace", "x")
+    assert report.valid_count == 1 and report.duplicate_count == 1
+
+
+def test_nullable_optionals_accepted():
+    rec = _record(
+        latitude=None,
+        longitude=None,
+        capacity_mw=None,
+        capacity_factor=None,
+        activity_confidence=None,
+        emissions_tonnes=None,
+        emissions_factor=None,
+    )
+    valid, report = DataValidator().validate_file([rec], "climatetrace", "x")
+    assert report.valid_count == 1
+
+
+# --- upsert SQL construction --------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.executed = []
+        self.rowcount = 3
+
+    def execute(self, sql):
+        self.executed.append(sql)
+
+    def copy_from(self, *a, **kw):
+        pass
+
+
+class _FakeConn:
+    def __init__(self):
+        self.cursor_obj = _FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _db():
+    return PowerGenerationDatabase(
+        host="localhost", port=5432, database="x", username="x", password="x"
+    )
+
+
+def _fake_engine(db, conn):
+    class _Eng:
+        def raw_connection(self):
+            return conn
+
+    # `engine` is a lazy property over _engine — inject there.
+    db._engine = _Eng()
+
+
+def test_upsert_with_update_columns_builds_do_update(monkeypatch):
+    db = _db()
+    conn = _FakeConn()
+    _fake_engine(db, conn)
+    df = pd.DataFrame(
+        [{"climatetrace_id": "1", "timestamp_ms": 1, "generation_mwh": 2.0}]
+    )
+    n = db._upsert_via_staging(
+        df,
+        "climatetrace_generation_data",
+        conflict_columns=["climatetrace_id", "timestamp_ms"],
+        update_columns=["generation_mwh", "ct_version"],
+    )
+    assert n == 3
+    insert_sql = conn.cursor_obj.executed[-1]
+    assert "INSERT INTO climatetrace_generation_data AS t" in insert_sql
+    assert "ON CONFLICT (climatetrace_id, timestamp_ms) DO UPDATE SET" in insert_sql
+    assert "generation_mwh = EXCLUDED.generation_mwh" in insert_sql
+    assert "ct_version = EXCLUDED.ct_version" in insert_sql
+    # The no-op guard: unchanged rows must not be rewritten.
+    assert (
+        "WHERE (t.generation_mwh, t.ct_version) IS DISTINCT FROM "
+        "(EXCLUDED.generation_mwh, EXCLUDED.ct_version)" in insert_sql
+    )
+
+
+def test_upsert_without_update_columns_stays_do_nothing():
+    db = _db()
+    conn = _FakeConn()
+    _fake_engine(db, conn)
+    df = pd.DataFrame([{"climatetrace_id": "1", "timestamp_ms": 1}])
+    db._upsert_via_staging(
+        df,
+        "climatetrace_generation_data",
+        conflict_columns=["climatetrace_id", "timestamp_ms"],
+    )
+    insert_sql = conn.cursor_obj.executed[-1]
+    assert "DO NOTHING" in insert_sql
+    assert "AS t" not in insert_sql
+    assert "DO UPDATE" not in insert_sql
+
+
+# --- loader behavior -----------------------------------------------------------
+
+
+def _run_loader(monkeypatch, recs, upsert_return=None):
+    db = _db()
+    captured = {"upsert_kwargs": None, "df": None}
+
+    def fake_upsert(df, table, **kwargs):
+        captured["df"] = df
+        captured["table"] = table
+        captured["upsert_kwargs"] = kwargs
+        return len(df) if upsert_return is None else upsert_return
+
+    monkeypatch.setattr(db, "_upsert_via_staging", fake_upsert)
+    monkeypatch.setattr(db, "_execute_with_retry", lambda fn: fn())
+
+    def fake_date_range(table, run_id):
+        captured["date_run_id"] = run_id
+        return (None, None)
+
+    def fake_meta(**kw):
+        captured["meta"] = kw
+        return True
+
+    monkeypatch.setattr(db, "_get_date_range_for_run", fake_date_range)
+    monkeypatch.setattr(db, "insert_extraction_metadata", fake_meta)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+        path = f.name
+    success, report = db.insert_climatetrace_jsonl_data(path)
+    return success, report, captured
+
+
+def test_loader_uses_update_columns_without_bookkeeping_fields(monkeypatch):
+    success, report, cap = _run_loader(monkeypatch, [_record(i) for i in range(3)])
+    assert success
+    kwargs = cap["upsert_kwargs"]
+    assert kwargs["conflict_columns"] == ["climatetrace_id", "timestamp_ms"]
+    update_cols = kwargs["update_columns"]
+    assert "generation_mwh" in update_cols and "ct_version" in update_cols
+    # Bookkeeping fields must NOT be updated on conflict — they are fresh
+    # every run and would defeat the IS DISTINCT FROM no-op guard.
+    assert "extraction_run_id" not in update_cols
+    assert "created_at_ms" not in update_cols
+
+
+def test_loader_drops_unknown_columns(monkeypatch):
+    recs = [_record(0, unexpected_field="x")]
+    success, report, cap = _run_loader(monkeypatch, recs)
+    assert success
+    assert "unexpected_field" not in cap["df"].columns
+
+
+def test_loader_metadata_keyed_to_file_run_id(monkeypatch):
+    success, report, cap = _run_loader(monkeypatch, [_record(i) for i in range(2)])
+    assert cap["date_run_id"] == FILE_RUN_ID
+    assert cap["meta"]["extraction_run_id"] == FILE_RUN_ID
+    assert cap["meta"]["source"] == "climatetrace"
+
+
+def test_zero_written_is_success_not_failure(monkeypatch):
+    # Re-loading an unchanged package writes 0 rows (no-op guard) — that is
+    # the weekly steady state, not a failure; and no metadata row is written.
+    success, report, cap = _run_loader(
+        monkeypatch, [_record(i) for i in range(2)], upsert_return=0
+    )
+    assert success is True
+    assert report.valid_count == 2
+    assert "meta" not in cap
+
+
+def test_all_invalid_fails_loudly(monkeypatch):
+    recs = [_record(0, generation_mwh=-1.0), _record(1, generation_mwh=-2.0)]
+    success, report, cap = _run_loader(monkeypatch, recs)
+    assert success is False
+
+
+def test_get_all_record_counts_includes_climatetrace():
+    import inspect
+
+    src = inspect.getsource(PowerGenerationDatabase.get_all_record_counts)
+    assert "climatetrace_generation_data" in src


### PR DESCRIPTION
## Summary
- New `climatetrace_generation_data` table + validated loader + weekly workflow job for the Climate TRACE extractor (energy-extractors [PR #11](https://github.com/nicholas-abad/energy-extractors/pull/11)) — monthly plant-level **modeled** generation, high-confidence subset, ~150K rows / 2,538 plants / 62 countries incl. China, Russia, Turkey.
- First **revision-aware** source: `_upsert_via_staging` gains an `update_columns` mode (`ON CONFLICT DO UPDATE ... WHERE ... IS DISTINCT FROM ...`) because Climate TRACE re-states history every release — `DO NOTHING` would freeze first-loaded estimates forever.
- One table for all countries (`country_code` column + `(country_code, timestamp_ms)` index), mirroring how `entsoe_generation` holds ~30 countries — deliberately NOT per-country tables.
- Fixes the adjacent audit finding: `rebuild-npp-crosswalk` was in `notify-failure.needs` but missing from its jobs map (failures produced an empty-body issue).

## Context
Climate TRACE ships one global bulk package (~25 MB, ~8s to process) covering 2021→now at monthly plant grain, and **revises past months between releases**. That inverts two house assumptions: there is no incremental window (the workflow job has no resolve-window step — the full re-pull *is* the revision mechanism), and conflicts must update rather than skip. The `IS DISTINCT FROM` guard keeps re-loads cheap and the write-count meaningful: the weekly steady state writes only new months plus genuine revisions.

Bookkeeping fields (`extraction_run_id`, `created_at_ms`) are deliberately excluded from the update set — they are fresh every run and would defeat the no-op guard; a row keeps the provenance of the run that last *changed* it, and `ct_version` records which package release it currently reflects.

## Changes
| File | Change |
|------|--------|
| `schema/climatetrace_generation.sql` | New table: natural key `(climatetrace_id, timestamp_ms)` (also the upsert conflict target), country/fuel/time indexes, coordinates included (no crosswalk join needed) |
| `src/database.py` | `update_columns` mode in `_upsert_via_staging`; `insert_climatetrace_jsonl_data`; `create_climatetrace_table` + `create_all_tables`; table whitelist + record-counts entries |
| `src/validator.py` | `CLIMATETRACE_SCHEMA` + `validate_climatetrace_record`; duplicate key = `(climatetrace_id, timestamp_ms)` |
| `src/database_management.py` | `setup` + `load-data` dispatch and choices for `climatetrace` |
| `.github/workflows/weekly-extraction.yml` | `extract-climatetrace` job (no window, no secrets beyond repo token); added to `notify-failure` needs **and** jobs map; `rebuild-npp-crosswalk` map-omission fix |
| `tests/test_climatetrace_loader.py` | 16 tests: validator schema, generated upsert SQL (DO UPDATE + no-op guard; DO NOTHING unchanged for other sources), update-set excludes bookkeeping fields, file-run-id metadata, zero-written == success, all-invalid fails loudly |

## Example walkthrough (verified against prod)
### Step 1 — China-only first load
`load-data climatetrace climatetrace_generation_..._etl.jsonl` (extracted with `--countries CHN`) → **49,432 inserted** (786 plants).

### Step 2 — full global load on top
Same command with the full-history file (149,803 records) → **written: 100,371** — exactly `149,803 − 49,432`; the `IS DISTINCT FROM` guard skipped every unchanged China row.

### Step 3 — identical re-load
→ `No new or revised records (data unchanged)`, **0 written**, load reports success (the weekly steady state).

Final prod state: `149,803 rows / 2,538 plants / 62 countries`; CHN coal sums reconcile with the package-level profile.

## Not in this PR
Dashboard integration (region/overlay + modeled-vs-metered labeling) and any decision about widening the other 7 sources to `DO UPDATE` (Climate TRACE is the only source that revises history; the others keep `DO NOTHING` untouched — pinned by a test).

## Test plan
- [x] `uv run pytest -q` — 68 passed (16 new)
- [x] `uv run ruff check .` + `ruff format --check` — clean (one pre-existing drift file left untouched)
- [x] Workflow YAML parses; `extract-climatetrace` present in jobs, `notify-failure.needs`, and jobs map
- [x] Live three-step prod verification above (insert → partial-overlap upsert → idempotent no-op)