### PR TITLE
feat: weekly refresh for the 9 Climate TRACE gap countries (medium confidence)

### DIFF
--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -598,6 +598,29 @@ jobs:
             uv run python src/database_management.py load-data climatetrace "$f"
           done
 
+      # These 9 coal countries have no metered grid-operator source AND are
+      # almost entirely MEDIUM confidence in Climate TRACE (high-only leaves
+      # them empty). They're loaded at medium+ so the dashboard's gap-country
+      # regions stay fresh — a deliberate, tightly-scoped exception to the
+      # global high-only default above. Separate output dir so this doesn't
+      # re-process the global file. Upsert makes the overlap with the global
+      # high load a no-op.
+      - name: Extract Climate TRACE gap countries (medium confidence)
+        run: |
+          cd extractors
+          uv run energy-extract climatetrace \
+            --countries IDN ZAF MEX CAN ARG PHL VNM MNG TWN \
+            --min-confidence medium \
+            --output ../extracted_data_ct_gap \
+            --log-level INFO
+
+      - name: Load Climate TRACE gap countries into Neon
+        run: |
+          for f in extracted_data_ct_gap/climatetrace_*_etl.jsonl; do
+            echo "Loading $f..."
+            uv run python src/database_management.py load-data climatetrace "$f"
+          done
+
       - name: Upload artifacts (on failure only)
         if: failure()
         uses: actions/upload-artifact@v4
@@ -605,7 +628,9 @@ jobs:
           name: climatetrace-extraction-${{ github.run_id }}
           path: |
             extracted_data/*.jsonl
+            extracted_data_ct_gap/*.jsonl
             extracted_data/logs/
+            extracted_data_ct_gap/logs/
             extracted_data/extraction_metadata_*.json
           retention-days: 14
 


### PR DESCRIPTION
## Summary
Adds a second extract+load step to the `extract-climatetrace` weekly job so the dashboard's 9 gap-country regions stay fresh.

## Context
Dashboard PR #21 added Indonesia, South Africa, Mexico, Canada, Argentina, Philippines, Vietnam, Mongolia, Taiwan as regions, backed by Climate TRACE. Those countries are almost entirely **medium** confidence (high-only leaves them empty), so they were loaded to prod at `--min-confidence medium`. But the existing weekly job extracts **global high-only** — meaning those 9 countries' medium rows would never refresh. This wires their weekly refresh.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/weekly-extraction.yml` | New steps in `extract-climatetrace`: extract the 9 countries with `--countries … --min-confidence medium` into a separate output dir, then upsert-load them. Artifacts path updated for failure debugging. |

Keeps the invariant **global high-only + these 9 at medium**, maintained automatically. Separate output dir avoids re-processing the global file; the upsert (`ON CONFLICT DO UPDATE`) makes any overlap a no-op.

## Test plan
- [x] Workflow YAML parses; both new steps present in the job
- [x] The exact commands were run manually against prod to seed the data (extract 53,504 rows → load 51,456 written), so they're proven; this automates them
- [ ] First scheduled run (or manual `workflow_dispatch` with source "Climate TRACE (global)") confirms the weekly path green