### PR TITLE
One global Climate TRACE extract at medium confidence

### DIFF
--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -547,7 +547,8 @@ jobs:
   # REVISES past months between releases — so every run re-extracts the full
   # history and the loader upserts (ON CONFLICT DO UPDATE) so revisions
   # propagate. Steady state writes only new months + genuine revisions.
-  # High-confidence-only by default (extractor --min-confidence high).
+  # Loaded at medium+ confidence for ALL countries (see the extract step) so the
+  # dashboard can offer confidence as a reader-selectable filter.
   # No credentials required — the download bucket is public.
   # ─────────────────────────────────────────────
   extract-climatetrace:
@@ -584,39 +585,36 @@ jobs:
           cd extractors
           uv sync
 
-      - name: Extract Climate TRACE data (full history, high confidence)
+      # ONE global extract at medium confidence, replacing the former
+      # global-high + 9-hardcoded-countries-at-medium pair. The dashboard exposes
+      # confidence as a reader-selectable filter across all Climate TRACE
+      # countries, so the load has to carry both tiers everywhere rather than
+      # medium for a hand-picked list. `activity_confidence` rides along on every
+      # row, which is what the dashboard filters on.
+      #
+      # "medium" is a deliberate FLOOR, not a no-op: Climate TRACE's activity
+      # scale does include "very low", and unrated plant-months rank below every
+      # minimum, so both are excluded here. That is the intent — every figure the
+      # dashboard shows is at least medium confidence.
+      #
+      # Do NOT rewrite this as `--min-confidence none` on the assumption that it
+      # is equivalent. It happened to drop no rows as of release v5.8.0, where
+      # Climate TRACE rated 23,212 plant-months "very low" but published activity
+      # data for none of them (765,996 ratings vs 742,784 data rows). No
+      # `--release` is pinned below and the extractor default is the moving
+      # `latest` alias, so treat those counts as a v5.8.0 observation, not a
+      # standing property.
+      - name: Extract Climate TRACE data (full history, medium+ confidence)
         run: |
           cd extractors
           uv run energy-extract climatetrace \
+            --min-confidence medium \
             --output ../extracted_data \
             --log-level INFO
 
       - name: Load Climate TRACE data into Neon
         run: |
           for f in extracted_data/climatetrace_*_etl.jsonl; do
-            echo "Loading $f..."
-            uv run python src/database_management.py load-data climatetrace "$f"
-          done
-
-      # These 9 coal countries have no metered grid-operator source AND are
-      # almost entirely MEDIUM confidence in Climate TRACE (high-only leaves
-      # them empty). They're loaded at medium+ so the dashboard's gap-country
-      # regions stay fresh — a deliberate, tightly-scoped exception to the
-      # global high-only default above. Separate output dir so this doesn't
-      # re-process the global file. Upsert makes the overlap with the global
-      # high load a no-op.
-      - name: Extract Climate TRACE gap countries (medium confidence)
-        run: |
-          cd extractors
-          uv run energy-extract climatetrace \
-            --countries IDN ZAF MEX CAN ARG PHL VNM MNG TWN \
-            --min-confidence medium \
-            --output ../extracted_data_ct_gap \
-            --log-level INFO
-
-      - name: Load Climate TRACE gap countries into Neon
-        run: |
-          for f in extracted_data_ct_gap/climatetrace_*_etl.jsonl; do
             echo "Loading $f..."
             uv run python src/database_management.py load-data climatetrace "$f"
           done
@@ -628,9 +626,7 @@ jobs:
           name: climatetrace-extraction-${{ github.run_id }}
           path: |
             extracted_data/*.jsonl
-            extracted_data_ct_gap/*.jsonl
             extracted_data/logs/
-            extracted_data_ct_gap/logs/
             extracted_data/extraction_metadata_*.json
           retention-days: 14
 

--- a/.github/workflows/weekly-extraction.yml
+++ b/.github/workflows/weekly-extraction.yml
@@ -592,10 +592,10 @@ jobs:
       # medium for a hand-picked list. `activity_confidence` rides along on every
       # row, which is what the dashboard filters on.
       #
-      # "medium" is a deliberate FLOOR, not a no-op: Climate TRACE's activity
-      # scale does include "very low", and unrated plant-months rank below every
-      # minimum, so both are excluded here. That is the intent — every figure the
-      # dashboard shows is at least medium confidence.
+      # "medium" is a deliberate FLOOR, not a no-op. It excludes three things:
+      # "very low" and "low" ratings (both are on Climate TRACE's activity scale),
+      # and unrated plant-months, which rank below every minimum. That is the
+      # intent — every figure the dashboard shows is at least medium confidence.
       #
       # Do NOT rewrite this as `--min-confidence none` on the assumption that it
       # is equivalent. It happened to drop no rows as of release v5.8.0, where

--- a/schema/climatetrace_generation.sql
+++ b/schema/climatetrace_generation.sql
@@ -1,9 +1,12 @@
 -- Climate TRACE Power Generation Data (global, MODELED)
 -- Monthly per-plant generation + emissions estimates from the Climate TRACE
 -- bulk download packages (satellite + ML estimates, NOT metered readings —
--- unlike every other source table). By default only plant-months whose
--- generation estimate Climate TRACE rates 'high'+ are extracted (~2.5K
--- plants globally, the reported-data-backed subset).
+-- unlike every other source table). The weekly job loads plant-months whose
+-- generation estimate Climate TRACE rates 'medium' or better, for all
+-- countries; `activity_confidence` records the rating per row, and the
+-- dashboard lets the reader restrict the view to the 'high' (reported-data-
+-- backed) subset. Ratings below medium, and unrated plant-months, are excluded
+-- at extraction.
 -- One table for ALL countries (country_code column), mirroring how
 -- entsoe_generation holds ~30 countries — do not split per country.
 -- Data source: https://downloads.climatetrace.org


### PR DESCRIPTION
## Summary

- Replaces the **global-high + 9-hardcoded-countries-at-medium** extract pair with a **single global `--min-confidence medium`** extract and load.
- Every country now carries both confidence tiers, so the dashboard can expose confidence as a reader control instead of inheriting a fixed tier from the pipeline.
- Removes the dead `extracted_data_ct_gap` output directory and its artifact paths.
- Corrects two stale claims: the job header said high-confidence-only by default, and the schema header described the high-only subset.

## Context

The Climate TRACE job ran twice: once globally at `high` confidence, then again for nine hardcoded countries at `medium`, because those nine are almost entirely medium-rated and high-only left them empty. That worked while the dashboard shipped one fixed tier and nine gap countries.

The dashboard now surfaces confidence as a **reader-selectable filter** across ~52 countries (nicholas-abad/energy-generation-dashboard#32), which changes what the pipeline owes it: both tiers for *every* country, not medium for a hand-picked list. Since `activity_confidence` already rides along on each row and the loader is revision-aware (`ON CONFLICT DO UPDATE` with an `IS DISTINCT FROM` guard), this is a matter of dropping `--countries` and lowering the floor once — the overlap with existing rows is a verified no-op.

`medium` is a deliberate floor rather than a no-op, and the comment now says so explicitly. Climate TRACE's activity scale *does* include "very low", and unrated plant-months rank below every minimum, so both are excluded — every figure the dashboard shows is at least medium confidence. It happens to drop nothing as of v5.8.0 only because Climate TRACE rates those plant-months without publishing activity data for them (765,996 ratings vs 742,784 data rows). No `--release` is pinned and the extractor default is the moving `latest` alias, so that is a v5.8.0 observation, not a standing property — hence the explicit warning not to "simplify" this to `--min-confidence none`.

## Changes

| File | Change |
|---|---|
| `.github/workflows/weekly-extraction.yml` | Collapses the two extract+load step pairs into one global `--min-confidence medium` run; drops the `extracted_data_ct_gap` artifact paths; rewrites the job header and the floor rationale. |
| `schema/climatetrace_generation.sql` | Header now describes what is actually loaded (medium+ for all countries, with `activity_confidence` per row) instead of the high-only subset. |

## Test plan

- [x] `uv run ruff check src/` — All checks passed
- [x] `uv run ruff format --check src/` — 8 files already formatted
- [x] `uv run pytest tests/ -q` — **68 passed**
- [x] Workflow YAML parses; `extract-climatetrace` is now 9 steps (was 11)
- [x] No dangling references: `extracted_data_ct_gap` is gone repo-wide; `needs:` graph and the `notify-failure` job map are unchanged, so CT failures still open an issue
- [x] **Ran end-to-end against prod**: extract kept 742,784 of 742,784 rows (0 below the floor); the load wrote **541,525**, and the remainder — exactly the prior table size of 201,259 — was verified unchanged by the `IS DISTINCT FROM` guard
- [x] Post-load state: 742,784 rows / 182 countries; coal subset 201,856 rows across 87 countries
- [x] Wall time ~70s (extract 16s, load 54s), well inside `timeout-minutes: 30`